### PR TITLE
Initial AHS device

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.35.0",
-        "pennylane==0.29.1",
+        # "pennylane=0.30.0"
+        "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     ],
     entry_points={
         "pennylane.plugins": [
@@ -39,6 +40,8 @@ setup(
             # `pennylane.device` device loader.
             "braket.aws.qubit = braket.pennylane_plugin:BraketAwsQubitDevice",
             "braket.local.qubit = braket.pennylane_plugin:BraketLocalQubitDevice",
+            "braket.aws.aquila = braket.pennylane_plugin:BraketAquilaDevice",
+            "braket.local.aquila = braket.pennylane_plugin:BraketLocalAquilaDevice",
         ]
     },
     extras_require={
@@ -61,6 +64,8 @@ setup(
             "tox",
             "tensorflow>=2.6.0",
             "torch>=1.11",
+            "jax==0.4.3",
+            "jaxlib==0.4.3"
         ]
     },
     url="https://github.com/aws/amazon-braket-pennylane-plugin-python",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.35.0",
-        # "pennylane=0.30.0"
+
         "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     ],
     entry_points={
@@ -62,10 +62,10 @@ setup(
             "sphinx-rtd-theme",
             "sphinxcontrib-apidoc",
             "tox",
-            "tensorflow>=2.6.0",
+            "tensorflow-macos>=2.6.0",
             "torch>=1.11",
-            "jax==0.4.3",
-            "jaxlib==0.4.3"
+            # "jax==0.4.3",
+            # "jaxlib==0.4.3"
         ]
     },
     url="https://github.com/aws/amazon-braket-pennylane-plugin-python",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.35.0",
-
+        # "pennylane=0.30.0"
         "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     ],
     entry_points={
@@ -62,10 +62,8 @@ setup(
             "sphinx-rtd-theme",
             "sphinxcontrib-apidoc",
             "tox",
-            "tensorflow-macos>=2.6.0",
+            "tensorflow>=2.6.0",
             "torch>=1.11",
-            # "jax==0.4.3",
-            # "jaxlib==0.4.3"
         ]
     },
     url="https://github.com/aws/amazon-braket-pennylane-plugin-python",

--- a/src/braket/pennylane_plugin/__init__.py
+++ b/src/braket/pennylane_plugin/__init__.py
@@ -15,6 +15,10 @@ from braket.pennylane_plugin.braket_device import (  # noqa: F401
     BraketAwsQubitDevice,
     BraketLocalQubitDevice,
 )
+from braket.pennylane_plugin.ahs_device import (
+    BraketAquilaDevice,
+    BraketLocalAquilaDevice,
+)
 from braket.pennylane_plugin.ops import (  # noqa: F401
     MS,
     PSWAP,

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -1,0 +1,244 @@
+from functools import partial
+import numpy as np
+
+from braket.aws import AwsDevice
+from braket.devices import LocalSimulator
+from braket.ahs.atom_arrangement import AtomArrangement
+from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
+from braket.ahs.driving_field import DrivingField
+from braket.timings.time_series import TimeSeries
+
+from pennylane import QubitDevice
+from pennylane._version import __version__
+from pennylane.pulse import RydbergHamiltonian
+
+
+class QuEraAquila(QubitDevice):
+    """Amazon Braket AwsDevice interface for analogue hamiltonian simulation on QuEra Aquila for PennyLane."""
+
+    name = "Braket QuEra Aquila PennyLane plugin"
+    short_name = "quera.aquila"
+    pennylane_requires = ">=0.29.0"
+    version = __version__
+    author = "Xanadu Inc."
+
+    operations = {"ParametrizedEvolution"}
+
+    ARN_NR = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
+
+    def __init__(
+            self,
+            wires,
+            *,
+            shots=100,
+            simulator=True):
+
+        self.shots = shots
+        self.simulator = simulator
+
+        super().__init__(wires=wires, shots=shots)
+
+        if simulator:  # this should be a separate thing long-term, this is just for ease of development and testing
+            self._device = LocalSimulator("braket_ahs")
+        else:
+            self._device = AwsDevice(self.ARN_NR)
+
+        self.circuit = []
+        self.ahs_program = None
+        self.samples = None
+
+    def reset(self):
+        """Reset the device and reload configurations."""
+        self.circuit = []
+        self.ahs_program = None
+        self.samples = None
+
+    @property
+    def hardware_capabilities(self):
+        return self._device.properties.paradigm.dict()
+
+    def apply(self, operations, **kwargs):
+
+        self._validate_operations(operations)
+
+        ev_op = operations[0]  # only one!
+
+        ahs_program = self.create_ahs_program(ev_op)
+
+        if self.simulator:
+            task = self._device.run(ahs_program, shots=self.shots, steps=100)
+
+        else:
+            discretized_ahs_program = ahs_program.discretize(self._device)
+            task = self._device.run(discretized_ahs_program, shots=self.shots)
+
+        self.samples = task.result()
+
+    def create_ahs_program(self, evolution):
+        """Create AHS program for upload to hardware from a ParametrizedEvolution"""
+
+        params = evolution.parameters
+
+        # sets self.pulses to be the evaluated pulses (now only a function of time)
+        self._evaluate_pulses(evolution, params)
+        # creates AtomArrangement object from H.register
+        self._create_register(evolution.H.register)
+
+        # if multiple operators were allowed, there would be multiple time intervals here.
+        # need to think about constraints in terms of how/whether these can overlap, as well as
+        time_interval = evolution.t
+
+        # no gurarentee that global drive is index 0 once we start allowing more just global drive
+        drive = self._convert_pulse_to_driving_field(self.pulses[0], time_interval)
+
+        # currently not being tested, but this will not be the correct way to handle this
+        # I don't think multiple global drives should be an option in the same time_interval
+        # and if additional drives aren't global drives, they will need to be implemented differently
+        # (i.e. check only detuning is defined and use braket.ahs.ShiftingField instead of DrivingField)
+        # if we wait to implement local control until outside PL until it's available on HW, this is not needed yet
+        if len(self.pulses) > 1:
+            for pulse in self.pulses[1:]:
+                drive += self._convert_pulse_to_driving_field(pulse, time_interval)
+
+        ahs_program = AnalogHamiltonianSimulation(register=self.register, hamiltonian=drive)
+
+        self.ahs_program = ahs_program
+
+        return ahs_program
+
+    def generate_samples(self):
+        return [self._result_to_sample_output(res) for res in self.samples.measurements]
+
+    def _validate_operations(self, operations):
+
+        if len(operations) > 1:
+            raise NotImplementedError(
+                f"Support for multiple ParametrizedEvolution operators in a single circuit is "
+                f"not yet implemented. Recieved {len(operations)} operators.")
+
+        ev_op = operations[0]  # only one!
+
+        if not isinstance(ev_op.H, RydbergHamiltonian):
+            raise RuntimeError(
+                f"Expected a RydbergHamiltonian instance for interfacing with the device, but "
+                f"recieved {type(ev_op.H)}.")
+
+        if len(ev_op.H.pulses) > 1:
+            raise NotImplementedError(
+                f"Support for multiple pulses in a Rydberg Hamiltonian not currently supported on "
+                f"hardware or in simulation")
+            #  ToDo: add local drive (detuning only, uses different mechanism)
+            #  Could be skipped for now as it's an upcoming feature on hardware, currently only supported in simulation)
+
+        if ev_op.H.pulses[0].wires != self.wires:
+            raise NotImplementedError(
+                f"Only global drive is currently supported. Found drive defined for subset "
+                f"{[ev_op.H.pulses[0].wires]} of all wires [{self.wires}]")
+
+    # could be static method or just completely separate from the class
+    def _create_register(self, coordinates):
+        register = AtomArrangement()
+        for [x, y] in coordinates:
+            register.add([x * 1e-6, y * 1e-6])  # we ask users to specify in um, braket expects SI units
+
+        self.register = register
+
+    def _evaluate_pulses(self, ev_op, params):
+
+        # ToDo: what happens if H.pulses is an empty list? I.e. if only interaction term
+        pulses = ev_op.H.pulses
+        coeffs = ev_op.H.coeffs_parametrized
+
+        evaluated_coeffs = [partial(fn, param) for fn, param in zip(coeffs, params)]
+
+        idx = 0
+
+        for pulse in pulses:
+            # is this a dangerous choice? (I think so.) Can these orders be easily mixed up?
+            # yes but same problem with coeffs, params? think about this after resolving phase-as-a-callable
+            if callable(pulse.amplitude):
+                pulse.amplitude = evaluated_coeffs[idx]
+                idx += 1
+
+            if callable(pulse.detuning):
+                pulse.detuning = evaluated_coeffs[idx]
+                idx += 1
+
+            if callable(pulse.phase):
+                pulse.phase = evaluated_coeffs[idx]
+                idx += 1
+
+        self.pulses = pulses
+
+    # could be static
+    def _get_sample_times(self, time_interval):
+        # time_interval from PL is in microseconds
+        interval_ns = np.array(time_interval) * 1e3
+        timespan = interval_ns[1] - interval_ns[0]
+
+        # number of points must ensure at least 50ns between sample points
+        num_points = int(timespan // 50)
+
+        start = interval_ns[0]
+        end = interval_ns[1]
+
+        # we want an integer number of nanoseconds
+        times = np.linspace(start, end, num_points, dtype=int)
+
+        # we return time in seconds
+        return times / 1e9
+
+    # could be static?
+    def _convert_to_time_series(self, coeff, time_points, scaling_factor=1):
+
+        ts = TimeSeries()
+
+        if callable(coeff):
+            # time is now in ns, but fn is defined assuming time in us? maybe we should commit to ns
+            vals = [float(coeff(t * 1e6))*scaling_factor for t in time_points]
+        else:
+            vals = [coeff for t in time_points]
+
+        for t, v in zip(time_points, vals):
+            ts.put(t, v)
+
+        return ts
+
+    # could be static?
+    def _convert_pulse_to_driving_field(self, pulse, time_interval):
+
+        time_points = self._get_sample_times(time_interval)
+
+        # scaling factor for amplitude and detunig convert MHz (expected PL input) to rad/s (upload units)
+        amplitude = self._convert_to_time_series(pulse.amplitude, time_points, scaling_factor=2*np.pi*1e6)
+        detuning = self._convert_to_time_series(pulse.detuning, time_points, scaling_factor=2*np.pi*1e6)
+        phase = self._convert_to_time_series(pulse.phase, time_points)
+
+        drive = DrivingField(amplitude=amplitude, detuning=detuning, phase=phase)
+
+        return drive
+
+    @staticmethod
+    def _result_to_sample_output(res):
+        """This function converts a single shot of the QuEra measurement results to 0 (ground), 1 (excited)
+        and NaN (failed to measure) for all atoms in the result.
+
+        The QuEra results are summarized via 3 values: status, pre_sequence, and post_sequence.
+
+        Status is success or fail. The pre_sequence is 1 if an atom in the ground state was successfully
+        initialized, and 0 otherwise. The post_sequence is 1 if an atom in the ground state was measured, \
+        and 0 otherwise. Comparison of pre_sequence and post_sequence reveals one of 3 possible outcomes:
+
+        0 --> 0: Atom failed to be placed, no measurement (no atom in the ground state either before or after)
+        1 --> 0: Atom initialized, measured in Rydberg state (atom in ground state detected before, but not after)
+        1 --> 1: Atom initialized, measured in ground state (atom in ground state detected both before and after)"""
+
+        # if entire measurement failed, all NaN
+        if not res.status.value.lower() == 'success':
+            return [np.NaN, np.NaN, np.NaN]
+
+        # if a single atom failed to initialize, NaN for that individual measurement
+        pre_sequence = [i if i else np.NaN for i in res.pre_sequence]
+
+        # set entry to 0 if ground state is measured, 1 if excited state is measured, NaN if measurement failed
+        return np.array(pre_sequence - res.post_sequence)

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -38,7 +38,7 @@ class BraketAhsDevice(QubitDevice):
             shots=100):
 
         if not shots:
-            raise RuntimeError(f"This device requires shots. Recieved shots={shots}")
+            raise RuntimeError(f"This device requires shots. Received shots={shots}")
         self._device = device
         super().__init__(wires=wires, shots=shots)
 
@@ -142,7 +142,7 @@ class BraketAhsDevice(QubitDevice):
 
     def _evaluate_pulses(self, ev_op):
         """Feeds in the parameters in order to partially evaluate the callables (amplitude, phase and/or detuning)
-        describing the pulses, so they are only a function of time. Saves the on the device as `dev.pulses`.
+        describing the pulses, so they are only a function of time. Saves the pulses on the device as `dev.pulses`.
 
         Args:
             ev_op(ParametrizedEvolution): the operator containing the pulses to be evaluated
@@ -274,7 +274,7 @@ class BraketAhsDevice(QubitDevice):
 
 
 class BraketAquilaDevice(BraketAhsDevice):
-    """Amazon Braket AHS device for QuEra Aquila hardware for PennyLane.
+    """Amazon Braket AHS device on QuEra Aquila hardware for PennyLane.
 
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -37,8 +37,8 @@ class BraketAhsDevice(QubitDevice):
             *,
             shots=100):
 
-        if shots is None:
-            raise RuntimeError("Number of shots must be defined. Recieved shots=None")
+        if not shots:
+            raise RuntimeError(f"This device requires shots. Recieved shots={shots}")
         self._device = device
         super().__init__(wires=wires, shots=shots)
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -116,6 +116,15 @@ class BraketAhsDevice(QubitDevice):
                 f"Expected a RydbergHamiltonian instance for interfacing with the device, but "
                 f"recieved {type(ev_op.H)}.")
 
+        if not set(ev_op.wires) == set(self.wires):
+            raise RuntimeError(f'Device contains wires {self.wires}, but received a `ParametrizedEvolution` operator '
+                               f'working on wires {ev_op.wires}. Device wires must match wires of the evolution.')
+
+        if len(ev_op.H.register) != len(self.wires):
+            raise RuntimeError(f'The defined interaction term has register {ev_op.H.register} of length '
+                               f'{len(ev_op.H.register)}, which does not match the number of wires on the device '
+                               f'({len(self.wires)})')
+
         self._validate_pulses(ev_op.H.pulses)
 
     def _validate_pulses(self, pulses):
@@ -344,6 +353,9 @@ class BraketLocalAquilaDevice(BraketAhsDevice):
         return task
 
     def _validate_pulses(self, pulses):
+
+        if not pulses:
+            raise RuntimeError("No pulses found in the ParametrizedEvolution")
 
         if len(pulses) > 1:
             raise NotImplementedError(

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -37,6 +37,8 @@ class BraketAhsDevice(QubitDevice):
             *,
             shots=100):
 
+        if shots is None:
+            raise RuntimeError("Number of shots must be defined. Recieved shots=None")
         self._device = device
         super().__init__(wires=wires, shots=shots)
 
@@ -122,10 +124,10 @@ class BraketAhsDevice(QubitDevice):
     def _create_register(self, coordinates):
         """Create an AtomArrangement to describe the atom layout from the coordinates in the ParametrizedEvolution"""
 
-
         register = AtomArrangement()
         for [x, y] in coordinates:
-            register.add([x * 1e-6, y * 1e-6])  # PL asks users to specify in um, Braket expects SI units
+            # PL asks users to specify in um, Braket expects SI units
+            register.add([x*1e-6, y*1e-6])
 
         self.register = register
 
@@ -297,6 +299,7 @@ class BraketAquilaDevice(BraketAhsDevice):
     def _run_task(self, ahs_program):
         discretized_ahs_program = ahs_program.discretize(self._device)
         task = self._device.run(discretized_ahs_program, shots=self.shots)
+        return task
 
     def _validate_pulses(self, pulses):
 
@@ -341,8 +344,6 @@ class BraketLocalAquilaDevice(BraketAhsDevice):
         return task
 
     def _validate_pulses(self, pulses):
-
-        # ToDo: allow local drive
 
         if len(pulses) > 1:
             raise NotImplementedError(

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from pennylane import QubitDevice
 from pennylane._version import __version__
-from pennylane.pulse.rydberg_hamiltonian import RydbergHamiltonian, RydbergPulse
+from pennylane.pulse.hardware_hamiltonian import HardwarePulse, HardwareHamiltonian
 
 from braket.aws import AwsDevice
 from braket.devices import Device, LocalSimulator
@@ -174,10 +174,10 @@ class BraketAhsDevice(QubitDevice):
             )
 
     def _validate_pulses(self, pulses):
-        """Confirms that the list of RydbergPulses describes a single, global pulse
+        """Confirms that the list of HardwarePulses describes a single, global pulse
 
         Args:
-            pulses: List of RydbergPulses
+            pulses: List of HardwarePulses
 
         Raises:
             RuntimeError, NotImplementedError"""
@@ -187,8 +187,8 @@ class BraketAhsDevice(QubitDevice):
 
         if len(pulses) > 1:
             raise NotImplementedError(
-                f"Multiple pulses in a Rydberg Hamiltonian are not currently supported on "
-                f"hardware. Recieved {len(pulses)} pulses."
+                f"Multiple pulses in a Hamiltonian are not currently supported. "
+                f"Recieved {len(pulses)} pulses."
             )
 
         if pulses[0].wires != self.wires:

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -31,7 +31,7 @@ Classes
 Code details
 ~~~~~~~~~~~~
 """
-
+from enum import Enum, auto
 from functools import partial
 from typing import Iterable, Union
 import numpy as np
@@ -40,12 +40,13 @@ from pennylane import QubitDevice
 from pennylane._version import __version__
 from pennylane.pulse.hardware_hamiltonian import HardwarePulse, HardwareHamiltonian
 
-from braket.aws import AwsDevice
+from braket.aws import AwsDevice, AwsSession, AwsQuantumTask
 from braket.devices import Device, LocalSimulator
 from braket.ahs.atom_arrangement import AtomArrangement
 from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
 from braket.ahs.driving_field import DrivingField
 from braket.timings.time_series import TimeSeries
+
 
 
 class BraketAhsDevice(QubitDevice):
@@ -66,7 +67,12 @@ class BraketAhsDevice(QubitDevice):
 
     operations = {"ParametrizedEvolution"}
 
-    def __init__(self, wires: Union[int, Iterable], device: Device, *, shots=100):
+    def __init__(
+            self,
+            wires: Union[int, Iterable],
+            device: Device, *,
+            shots: int = 100
+    ):
         if not shots:
             raise RuntimeError(f"This device requires shots. Recieved shots={shots}")
         self._device = device
@@ -367,7 +373,15 @@ class BraketAquilaDevice(BraketAhsDevice):
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
+        s3_destination_folder (AwsSession.S3DestinationFolder): Name of the S3 bucket
+            and folder, specified as a tuple.
         shots (int): Number of executions to run to aquire measurements. Defaults to 100.
+        aws_session (Optional[AwsSession]): An AwsSession object created to manage
+            interactions with AWS services, to be supplied if extra control
+            is desired. Default: None
+        poll_timeout_seconds (float): Total time in seconds to wait for
+            results before timing out.
+        poll_interval_seconds (float): The polling interval for results in seconds.
 
     """
 
@@ -376,12 +390,26 @@ class BraketAquilaDevice(BraketAhsDevice):
 
     ARN_NR = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
 
-    def __init__(self, wires: Union[int, Iterable], *, shots=100):
-        device = AwsDevice(self.ARN_NR)
+    def __init__(
+            self,
+            wires: Union[int, Iterable],
+            s3_destination_folder: AwsSession.S3DestinationFolder = None,
+            *,
+            shots: int = 100,
+            poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+            poll_interval_seconds : float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
+            aws_session: Optional[AwsSession] = None,
+    ):
+        device = AwsDevice(self.ARN_NR, aws_session=aws_session)
+        user_agent = f"BraketPennylanePlugin/{__version__}"
+        device.aws_session.add_braket_user_agent(user_agent)
+        
         super().__init__(wires=wires, device=device, shots=shots)
 
-        self.ahs_program = None
-        self.samples = None
+        self._s3_folder = s3_destination_folder
+        self._poll_timeout_seconds = poll_timeout_seconds
+        self._poll_interval_seconds = poll_interval_seconds
+
 
     @property
     def hardware_capabilities(self):
@@ -390,7 +418,13 @@ class BraketAquilaDevice(BraketAhsDevice):
 
     def _run_task(self, ahs_program):
         discretized_ahs_program = ahs_program.discretize(self._device)
-        task = self._device.run(discretized_ahs_program, shots=self.shots)
+        task = self._device.run(
+            discretized_ahs_program,
+            s3_destination_folder=self._s3_folder,
+            shots=self.shots,
+            poll_timeout_seconds=self._poll_timeout_seconds,
+            poll_interval_seconds=self._poll_interval_seconds,
+        )
         return task
 
 
@@ -407,7 +441,12 @@ class BraketLocalAquilaDevice(BraketAhsDevice):
     name = "Braket QuEra Aquila PennyLane plugin"
     short_name = "braket.local.aquila"
 
-    def __init__(self, wires: Union[int, Iterable], *, shots=100):
+    def __init__(
+            self,
+            wires: Union[int, Iterable],
+            *,
+            shots=100
+    ):
         device = LocalSimulator("braket_ahs")
         super().__init__(wires=wires, device=device, shots=shots)
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -11,7 +11,7 @@ from braket.timings.time_series import TimeSeries
 
 from pennylane import QubitDevice
 from pennylane._version import __version__
-from pennylane.pulse.rydberg_hamiltonian import RydbergHamiltonian, RydbergPulse
+from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
 
 
 class BraketAhsDevice(QubitDevice):
@@ -107,7 +107,7 @@ class BraketAhsDevice(QubitDevice):
 
     def _validate_operations(self, operations):
         """Confirms that the list of operations provided contains a single ParametrizedEvolution
-        from a RydbergHamiltonian with only a single, global pulse"""
+        from a HardwareHamiltonian with only a single, global pulse"""
 
         if len(operations) > 1:
             raise NotImplementedError(
@@ -116,9 +116,9 @@ class BraketAhsDevice(QubitDevice):
 
         ev_op = operations[0]  # only one!
 
-        if not isinstance(ev_op.H, RydbergHamiltonian):
+        if not isinstance(ev_op.H, HardwareHamiltonian):
             raise RuntimeError(
-                f"Expected a RydbergHamiltonian instance for interfacing with the device, but "
+                f"Expected a HardwareHamiltonian instance for interfacing with the device, but "
                 f"recieved {type(ev_op.H)}.")
 
         if not set(ev_op.wires) == set(self.wires):
@@ -174,7 +174,7 @@ class BraketAhsDevice(QubitDevice):
                 detuning = partial(pulse.detuning, params[idx])
                 idx += 1
 
-            evaluated_pulses.append(RydbergPulse(amplitude=amplitude,
+            evaluated_pulses.append(HardwarePulse(amplitude=amplitude,
                                                  phase=phase,
                                                  detuning=detuning,
                                                  wires=pulse.wires))
@@ -228,11 +228,11 @@ class BraketAhsDevice(QubitDevice):
         return ts
 
     def _convert_pulse_to_driving_field(self, pulse, time_interval):
-        """Converts a ``RydbergPulse`` from PennyLane describing a global drive to a ``DrivingField``
+        """Converts a ``HardwarePulse`` from PennyLane describing a global drive to a ``DrivingField``
         from Braket AHS
 
         Args:
-            pulse[RydbergPulse]: a dataclass object containing amplitude, phase and detuning information
+            pulse[HardwarePulse]: a dataclass object containing amplitude, phase and detuning information
             time_interval(array[Number, Number]]): The start and end time for the applied pulse
 
         Returns:
@@ -322,7 +322,7 @@ class BraketAquilaDevice(BraketAhsDevice):
 
         if len(pulses) > 1:
             raise NotImplementedError(
-                f"Multiple pulses in a Rydberg Hamiltonian are not currently supported on "
+                f"Multiple pulses in a Hamiltonian are not currently supported on "
                 f"hardware. Recieved {len(pulses)} pulses.")
 
         if pulses[0].wires != self.wires:

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -31,7 +31,6 @@ Classes
 Code details
 ~~~~~~~~~~~~
 """
-from enum import Enum, auto
 from functools import partial
 from typing import Iterable, Union
 import numpy as np

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -40,11 +40,20 @@ class BraketAhsDevice(QubitDevice):
         self._device = device
         super().__init__(wires=wires, shots=shots)
 
+        self.register = None
         self.ahs_program = None
         self.samples = None
 
+    @property
+    def settings(self):
+        return {'interaction_coefficient': 862690}  # MHz x um^6
+
     def apply(self, operations, **kwargs):
         """Convert the pulse operation to an AHS program and run on the connected device"""
+
+        if not np.all([op.name in self.operations for op in operations]):
+            raise NotImplementedError("Device {self.short_name} expected only operations "
+                                      "{self.operations} but recieved {operations}")
 
         self._validate_operations(operations)
 
@@ -66,10 +75,8 @@ class BraketAhsDevice(QubitDevice):
             AnalogHamiltonianSimulation: a program containing the register and drive
                 information for running an AHS task on simulation or hardware"""
 
-        params = evolution.parameters
-
         # sets self.pulses to be the evaluated pulses (now only a function of time)
-        self._evaluate_pulses(evolution, params)
+        self._evaluate_pulses(evolution)
         self._create_register(evolution.H.register)
 
         time_interval = evolution.t
@@ -114,43 +121,51 @@ class BraketAhsDevice(QubitDevice):
 
     def _create_register(self, coordinates):
         """Create an AtomArrangement to describe the atom layout from the coordinates in the ParametrizedEvolution"""
+
+
         register = AtomArrangement()
         for [x, y] in coordinates:
             register.add([x * 1e-6, y * 1e-6])  # PL asks users to specify in um, Braket expects SI units
 
         self.register = register
 
-    def _evaluate_pulses(self, ev_op, params):
+    def _evaluate_pulses(self, ev_op):
         """Feeds in the parameters in order to partially evaluate the callables (amplitude, phase and/or detuning)
-        describing the pulses, so they are only a function of time
+        describing the pulses, so they are only a function of time. Saves the on the device as `dev.pulses`.
 
         Args:
             ev_op(ParametrizedEvolution): the operator containing the pulses to be evaluated
             params(list): a list of the parameters to be passed to the respective callables
         """
 
-        # ToDo: what happens if H.pulses is an empty list? I.e. if only interaction term
+        params = ev_op.parameters
         pulses = ev_op.H.pulses
-        coeffs = ev_op.H.coeffs_parametrized
 
-        evaluated_coeffs = [partial(fn, param) for fn, param in zip(coeffs, params)]
-
+        evaluated_pulses = []
         idx = 0
 
         for pulse in pulses:
+            amplitude = pulse.amplitude
             if callable(pulse.amplitude):
-                pulse.amplitude = evaluated_coeffs[idx]
+                amplitude = partial(pulse.amplitude, params[idx])
                 idx += 1
 
-            if callable(pulse.detuning):
-                pulse.detuning = evaluated_coeffs[idx]
-                idx += 1
-
+            phase = pulse.phase
             if callable(pulse.phase):
-                pulse.phase = evaluated_coeffs[idx]
+                phase = partial(pulse.phase, params[idx])
                 idx += 1
 
-        self.pulses = pulses
+            detuning = pulse.detuning
+            if callable(pulse.detuning):
+                detuning = partial(pulse.detuning, params[idx])
+                idx += 1
+
+            evaluated_pulses.append(RydbergPulse(amplitude=amplitude,
+                                                 phase=phase,
+                                                 detuning=detuning,
+                                                 wires=pulse.wires))
+
+        self.pulses = evaluated_pulses
 
     def _get_sample_times(self, time_interval):
         """Takes a time interval and returns an array of times with a minimum of 50ns spacing"""
@@ -175,7 +190,7 @@ class BraketAhsDevice(QubitDevice):
 
         Args:
             pulse_parameter(Union[float, Callable]): a physical parameter (pulse, amplitude or detuning) of the
-                pulse. If this is a callalbe, it has alreayd been partially evaluated, such that it is only a
+                pulse. If this is a callalbe, it has already been partially evaluated, such that it is only a
                 function of time.
             time_points(array): the times where parameters will be set in the TimeSeries, specified in seconds
             scaling_factor(float): A multiplication factor for the pulse_parameter where relevant to convert
@@ -238,7 +253,7 @@ class BraketAhsDevice(QubitDevice):
 
         # if entire measurement failed, all NaN
         if not res.status.value.lower() == 'success':
-            return [np.NaN for i in res.pre_sequence]
+            return np.array([np.NaN for i in res.pre_sequence])
 
         # if a single atom failed to initialize, NaN for that individual measurement
         pre_sequence = [i if i else np.NaN for i in res.pre_sequence]
@@ -284,6 +299,9 @@ class BraketAquilaDevice(BraketAhsDevice):
         task = self._device.run(discretized_ahs_program, shots=self.shots)
 
     def _validate_pulses(self, pulses):
+
+        if not pulses:
+            raise RuntimeError("No pulses found in the ParametrizedEvolution")
 
         if len(pulses) > 1:
             raise NotImplementedError(

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -1,6 +1,5 @@
 from functools import partial
 from typing import Iterable, Union
-from abc import ABC
 import numpy as np
 
 from braket.aws import AwsDevice
@@ -15,7 +14,7 @@ from pennylane._version import __version__
 from pennylane.pulse.rydberg_hamiltonian import RydbergHamiltonian, RydbergPulse
 
 
-class BraketAhsDevice(QubitDevice, ABC):
+class BraketAhsDevice(QubitDevice):
     """Abstract Amazon Braket device for analogue hamiltonian simulation with PennyLane.
 
     Args:
@@ -42,7 +41,7 @@ class BraketAhsDevice(QubitDevice, ABC):
 
         if not shots:
             raise RuntimeError(f"This device requires shots. Recieved shots={shots}")
-        self._device = backend
+        self._device = device
 
         super().__init__(wires=wires, shots=shots)
 
@@ -73,7 +72,6 @@ class BraketAhsDevice(QubitDevice, ABC):
 
         self.samples = task.result()
 
-    @abstractmethod
     def _run_task(self, ahs_program):
         raise NotImplementedError("Running a task not implemented for the base class")
 
@@ -325,8 +323,8 @@ class BraketAquilaDevice(BraketAhsDevice):
             *,
             shots=100):
 
-        backend = AwsDevice(self.ARN_NR)
-        super().__init__(wires=wires, backend=backend, shots=shots)
+        device = AwsDevice(self.ARN_NR)
+        super().__init__(wires=wires, device=device, shots=shots)
 
         self.ahs_program = None
         self.samples = None

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 """
 Devices
 =======

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -25,7 +25,7 @@ from pennylane.pulse.hardware_hamiltonian import HardwarePulse, drive
 
 from braket.pennylane_plugin.ahs_device import BraketAquilaDevice, BraketLocalAquilaDevice
 
-#ENTRY_POINTS = {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
+# ENTRY_POINTS = {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
 
 shortname_and_backendname = [("braket.local.aquila", "RydbergAtomSimulator"),
                              ("braket.aws.aquila", "Aquila")]
@@ -82,7 +82,7 @@ class TestBraketAquilaDevice:
         dev = BraketAquilaDevice(wires=3)
         pulses = [HardwarePulse(3, 4, 5, [0, 1]), HardwarePulse(4, 6, 7, [1, 2])]
 
-        with pytest.raises(NotImplementedError, match="Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
+        with pytest.raises(NotImplementedError, match="Multiple pulses in a Hamiltonian are not currently supported"):
             dev._validate_pulses(pulses)
 
     @pytest.mark.parametrize("pulse_wires, dev_wires, res", [([0, 1, 2], [0, 1, 2, 3], 'error'),
@@ -138,7 +138,7 @@ class TestDeviceAttributes:
         dev = BraketLocalAquilaDevice(wires=3, shots=shots)
         assert dev.shots == shots
 
-        global_drive = rydberg_drive(2, 1, 2, wires=[0, 1, 2])
+        global_drive = drive(2, 1, 2, wires=[0, 1, 2])
         ts = [0.0, 1.75]
 
         @qml.qnode(dev)

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -20,11 +20,12 @@ import pytest
 from conftest import shortname_and_backends
 
 from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
-from pennylane.pulse.rydberg_hamiltonian import rydberg_drive, rydberg_interaction, RydbergPulse
+from pennylane.pulse.rydberg import rydberg_interaction
+from pennylane.pulse.hardware_hamiltonian import HardwarePulse, drive
 
 from braket.pennylane_plugin.ahs_device import BraketAquilaDevice, BraketLocalAquilaDevice
 
-ENTRY_POINTS = {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
+#ENTRY_POINTS = {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
 
 shortname_and_backendname = [("braket.local.aquila", "RydbergAtomSimulator"),
                              ("braket.aws.aquila", "Aquila")]
@@ -49,16 +50,16 @@ params1 = 1.2
 params2 = [3.4, 5.6]
 params_amp = [2.5, 0.9, 0.3]
 
-# RydbergHamiltonians to be tested
+# Hamiltonians to be tested
 H_i = rydberg_interaction(coordinates)
 
-HAMILTONIANS_AND_PARAMS = [(H_i + rydberg_drive(1, 2, 3, wires=[0, 1, 2]), []),
-                           (H_i + rydberg_drive(amp, 1, 2, wires=[0, 1, 2]), [params_amp]),
-                           (H_i + rydberg_drive(2, f1, 2, wires=[0, 1, 2]), [params1]),
-                           (H_i + rydberg_drive(amp, 1, f2, wires=[0, 1, 2]), [params_amp, params2]),
-                           (H_i + rydberg_drive(4, f2, f1, wires=[0, 1, 2]), [params2, params1]),
-                           (H_i + rydberg_drive(amp, f2, 4, wires=[0, 1, 2]), [params_amp, params2]),
-                           (H_i + rydberg_drive(amp, f2, f1, wires=[0, 1, 2]), [params_amp, params2, params1])
+HAMILTONIANS_AND_PARAMS = [(H_i + drive(1, 2, 3, wires=[0, 1, 2]), []),
+                           (H_i + drive(amp, 1, 2, wires=[0, 1, 2]), [params_amp]),
+                           (H_i + drive(2, f1, 2, wires=[0, 1, 2]), [params1]),
+                           (H_i + drive(amp, 1, f2, wires=[0, 1, 2]), [params_amp, params2]),
+                           (H_i + drive(4, f2, f1, wires=[0, 1, 2]), [params2, params1]),
+                           (H_i + drive(amp, f2, 4, wires=[0, 1, 2]), [params_amp, params2]),
+                           (H_i + drive(amp, f2, f1, wires=[0, 1, 2]), [params_amp, params2, params1])
                 ]
 
 
@@ -79,7 +80,7 @@ class TestBraketAquilaDevice:
         """Test that an error is raised if there are multiple drive terms on
         the Hamiltonian"""
         dev = BraketAquilaDevice(wires=3)
-        pulses = [RydbergPulse(3, 4, 5, [0, 1]), RydbergPulse(4, 6, 7, [1, 2])]
+        pulses = [HardwarePulse(3, 4, 5, [0, 1]), HardwarePulse(4, 6, 7, [1, 2])]
 
         with pytest.raises(NotImplementedError, match="Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
             dev._validate_pulses(pulses)
@@ -92,7 +93,7 @@ class TestBraketAquilaDevice:
         """Test that an error is raised if the pulse does not describe a global drive"""
 
         dev = BraketAquilaDevice(wires=dev_wires)
-        pulse = RydbergPulse(3, 4, 5, pulse_wires)
+        pulse = HardwarePulse(3, 4, 5, pulse_wires)
 
         if res == 'error':
             with pytest.raises(NotImplementedError, match="Only global drive is currently supported"):

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -1,0 +1,200 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests that gates are correctly applied in the plugin device"""
+
+import numpy as np
+import pennylane as qml
+import pkg_resources
+import pytest
+from conftest import shortname_and_backends
+
+ENTRY_POINTS = {entry.name: entry for entry in pkg_resources.iter_entry_points("pennylane.plugins")}
+
+shortname_and_backendname = [("braket.local.aquila", "RydbergAtomSimulator"),
+                             ("braket.aws.aquila", "Aquila")]
+
+# =========================================================
+coordinates = [[0, 0], [0, 5], [5, 0]]  # in micrometers
+
+def f1(p, t):
+    return p * np.sin(t) * (t - 1)
+
+
+def f2(p, t):
+    return p[0] * np.cos(p[1] * t**2)
+
+
+# realistic amplitude function (0 at start and end for hardware)
+def amp(p, t):
+    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+    return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
+
+params1 = 1.2
+params2 = [3.4, 5.6]
+params_amp = [2.5, 0.9, 0.3]
+
+# RydbergHamiltonians to be tested
+H_fixed = rydberg_interaction(coordinates) + rydberg_drive(1, 2, 3, wires=3)
+
+HAMILTONIANS_AND_PARAMS = [(H_i + rydberg_drive(1, 2, 3, wires=[0, 1, 2]), []),
+                (H_i + rydberg_drive(amp, 1, 2, wires=[0, 1, 2]), [params_amp]),
+                (H_i + rydberg_drive(2, f1, 2, wires=[0, 1, 2]), [params1]),
+                (H_i + rydberg_drive(amp, 1, f2, wires=[0, 1, 2]), [params_amp, params2]),
+                (H_i + rydberg_drive(4, f2, f1, wires=[0, 1, 2]), [params2, params1]),
+                (H_i + rydberg_drive(amp, f2, 4, wires=[0, 1, 2]), [params_amp, params2]),
+                (H_i + rydberg_drive(amp, f2, f1, wires=[0, 1, 2]), [params_amp, params2, params1])
+                ]
+
+
+class TestBraketAquilaDevice:
+    """Test functionality specific to the hardware device that can be tested
+    without running a task on the hardware"""
+
+    def test_hardware_capabilities(self):
+        """Test hardware capabilities can be retrieved"""
+
+        assert isinstance(dev_hw.hardware_capabilities, dict)
+        assert 'rydberg' in dev_hw.hardware_capabilities.keys()
+        assert 'lattice' in dev_hw.hardware_capabilities.keys()
+
+    def test_validate_operations_multiple_drive_terms(self):
+        """Test that an error is raised if there are multiple drive terms on
+        the Hamiltonian"""
+        pulses = [RydbergPulse(3, 4, 5, [0, 1]), RydbergPulse(4, 6, 7, [1, 2])]
+
+        with pytest.raises(NotImplementedError, match="Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
+            dev_hw._validate_pulses(pulses)
+
+    @pytest.mark.parametrize("pulse_wires, dev_wires, res", [([0, 1, 2], [0, 1, 2, 3], 'error'),
+                                                             ([5, 6, 7, 8, 9], [4, 5, 6, 7, 8], 'error'),
+                                                             ([0, 1, 2, 3, 6], [1, 2, 3], 'error'),
+                                                             ([0, 1, 2], [0, 1, 2], 'success')])
+    def test_validate_pulse_is_global_drive(self, pulse_wires, dev_wires, res):
+        """Test that an error is raised if the pulse does not describe a global drive"""
+
+        dev = BraketAquilaDevice(wires=dev_wires)
+        pulse = RydbergPulse(3, 4, 5, pulse_wires)
+
+        if res == 'error':
+            with pytest.raises(NotImplementedError, match="Only global drive is currently supported"):
+                dev._validate_pulses([pulse])
+        else:
+            dev._validate_pulses([pulse])
+
+
+class TestDeviceIntegration:
+    """Test the devices work correctly from the PennyLane frontend."""
+
+    @pytest.mark.parametrize("shortname, backend_name", shortname_and_backends)
+    def test_load_device(self, name, backend_name):
+        """Test that the device loads correctly"""
+        dev = TestDeviceIntegration._device(name, wires=2)
+        assert dev.num_wires == 2
+        assert dev.shots is 100
+        assert dev.short_name == name
+        assert dev._device.name == backend_name
+
+    def test_args_aqulia(self):
+        """Test that BraketAwsDevice requires correct arguments"""
+        with pytest.raises(TypeError, match="missing 1 required positional arguments"):
+            qml.device("braket.aws.aquila")
+
+    def test_args_local(self):
+        """Test that BraketLocalDevice requires correct arguments"""
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            qml.device("braket.local.aquila")
+
+    @pytest.mark.parametrize("shortname", ["braket.local.aquila", "braket.aws.aquila"])
+    @pytest.mark.parametrize("shots", [4, 8192])
+    def test_one_qubit_circuit(self, shots, shortname, tol):
+        """Test that devices provide correct result for a simple circuit"""
+        dev = TestDeviceIntegration._device(shortname, wires=1, shots=shots)
+
+        @qml.qnode(dev)
+        def circuit():
+            """Reference QNode"""
+            qml.evolve(H_fixed)([], t)
+            return qml.sample()
+
+        assert np.allclose(circuit(params), np.cos(a) * np.sin(b), **tol)
+
+    # @staticmethod
+    # def _device(shortname_and_backend, wires, extra_kwargs):
+    #     device_name, backend = shortname_and_backend
+    #     device_class = ENTRY_POINTS[device_name].load()
+    #     return qml.device(device_name, wires=wires, **extra_kwargs(device_class, backend))
+
+    @staticmethod
+    def _device(shortname, wires, shots=100):
+        return qml.device(shortname, wires=wires, shots=shots)
+
+
+class TestDeviceAttributes:
+    """Test application of PennyLane operations on hardware simulators."""
+
+    @pytest.mark.parametrize("shots", [1003, 2])
+    def test_setting_shots(self, shots):
+        """Test that setting shots changes number of shots from default (100)"""
+        dev = BraketLocalAquilaDevice(wires=3, shots=shots)
+        assert dev.shots == shots
+
+        global_drive = rydberg_drive(2, 1, 2, wires=[0, 1, 2])
+        ts = jnp.array([0.0, 1.75])
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.evolve(H_i + global_drive)([], ts)
+            return qml.sample()
+
+        res = circuit()
+
+        assert len(res) == shots
+
+
+class TestQnodeIntegration:
+    pass
+#     def test_no_callables(self, H, params):
+#         """Test basis state initialization"""
+#         dev = device(4)
+#         t = 1.13
+#
+#         @qml.qnode(dev)
+#         def circuit():
+#             qml.evolve(H)(params, t)
+#             return qml.sample()
+#
+#         expected = np.zeros([2**4])
+#         expected[np.ravel_multi_index(state, [2] * 4)] = 1
+#         assert np.allclose(circuit(), expected, **tol)
+#
+#     def test_callable_amp(self, init_state, device, tol):
+#         pass
+#
+#     def test_callable_phase(self):
+#         pass
+#
+#     def test_callable_detuning(self):
+#         pass
+#
+#     def test_callable_amp_and_phase(self):
+#         pass
+#
+#     def test_callable_amp_and_detuning(self):
+#         pass
+#
+#     def test_callable_phase_and_detuning(self):
+#         pass
+#
+#     def test_callable_amp_phase_and_detuning(self):
+#         pass

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -18,7 +18,7 @@ import pennylane as qml
 import pkg_resources
 import pytest
 from conftest import shortname_and_backends
-from jax import numpy as jnp
+# from jax import numpy as jnp
 
 from pennylane.pulse.rydberg_hamiltonian import rydberg_drive, rydberg_interaction, RydbergPulse
 
@@ -32,6 +32,7 @@ shortname_and_backendname = [("braket.local.aquila", "RydbergAtomSimulator"),
 # =========================================================
 coordinates = [[0, 0], [0, 5], [5, 0]]  # in micrometers
 
+
 def f1(p, t):
     return p * np.sin(t) * (t - 1)
 
@@ -42,7 +43,7 @@ def f2(p, t):
 
 # realistic amplitude function (0 at start and end for hardware)
 def amp(p, t):
-    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+    f = p[0] * np.exp(-(t-p[1])**2/(2*p[2]**2))
     return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
 
 params1 = 1.2
@@ -138,7 +139,7 @@ class TestDeviceAttributes:
         assert dev.shots == shots
 
         global_drive = rydberg_drive(2, 1, 2, wires=[0, 1, 2])
-        ts = jnp.array([0.0, 1.75])
+        ts = np.array([0.0, 1.75])
 
         @qml.qnode(dev)
         def circuit():

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -19,6 +19,7 @@ import pkg_resources
 import pytest
 from conftest import shortname_and_backends
 
+from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
 from pennylane.pulse.rydberg_hamiltonian import rydberg_drive, rydberg_interaction, RydbergPulse
 
 from braket.pennylane_plugin.ahs_device import BraketAquilaDevice, BraketLocalAquilaDevice
@@ -137,7 +138,7 @@ class TestDeviceAttributes:
         assert dev.shots == shots
 
         global_drive = rydberg_drive(2, 1, 2, wires=[0, 1, 2])
-        ts = jnp.array([0.0, 1.75])
+        ts = [0.0, 1.75]
 
         @qml.qnode(dev)
         def circuit():

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -18,7 +18,6 @@ import pennylane as qml
 import pkg_resources
 import pytest
 from conftest import shortname_and_backends
-from jax import numpy as jnp
 
 from pennylane.pulse.rydberg_hamiltonian import rydberg_drive, rydberg_interaction, RydbergPulse
 
@@ -42,8 +41,8 @@ def f2(p, t):
 
 # realistic amplitude function (0 at start and end for hardware)
 def amp(p, t):
-    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
-    return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
+    return p[0] * np.exp(-(t-p[1])**2/(2*p[2]**2))
+
 
 params1 = 1.2
 params2 = [3.4, 5.6]
@@ -142,7 +141,7 @@ class TestDeviceAttributes:
 
         @qml.qnode(dev)
         def circuit():
-            qml.evolve(H_i + global_drive)([], ts)
+            ParametrizedEvolution(H_i + global_drive, [], ts)
             return qml.sample()
 
         res = circuit()
@@ -164,7 +163,7 @@ class TestQnodeIntegration:
 
         @qml.qnode(dev)
         def circuit():
-            qml.evolve(H)(params, t)
+            ParametrizedEvolution(H, params, t)
             return qml.sample()
 
         circuit()

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -1,0 +1,336 @@
+import json
+from typing import Any, Dict, Optional
+from unittest import mock
+from unittest.mock import Mock, PropertyMock, patch
+
+import braket.ir as ir
+import numpy as anp
+import pennylane as qml
+import pytest
+
+from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
+from braket.timings.time_series import TimeSeries
+from braket.ahs.driving_field import DrivingField
+from pennylane.pulse.rydberg_hamiltonian import RydbergHamiltonian, RydbergPulse
+from dataclasses import dataclass
+from braket.tasks.local_quantum_task import LocalQuantumTask
+from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import ShotResult
+
+from braket.aws import AwsDevice, AwsDeviceType, AwsQuantumTask, AwsQuantumTaskBatch
+from braket.circuits import Circuit, FreeParameter, Gate, Noise, Observable, result_types
+from braket.circuits.noise_model import GateCriteria, NoiseModel, NoiseModelInstruction
+from braket.device_schema import DeviceActionType
+from braket.device_schema.openqasm_device_action_properties import OpenQASMDeviceActionProperties
+from braket.device_schema.simulators import GateModelSimulatorDeviceCapabilities
+from braket.devices import LocalSimulator
+from braket.simulator import BraketSimulator
+from braket.task_result import GateModelTaskResult
+from braket.tasks import GateModelQuantumTaskResult
+from pennylane import QuantumFunctionError, QubitDevice
+from pennylane import numpy as np
+from pennylane.tape import QuantumTape
+
+import braket.pennylane_plugin.braket_device
+from braket.pennylane_plugin import BraketAwsQubitDevice, BraketLocalQubitDevice, __version__
+from braket.pennylane_plugin.braket_device import BraketQubitDevice, Shots
+
+
+coordinates1 = [[0, 0], [0, 5], [5, 0], [10, 5], [5, 10], [10, 10]]
+wires1 = [1, 6, 0, 2, 4, 3]
+
+coordinates2 = [[0, 0], [5.5, 0.0], [2.75, 4.763139720814412]]
+H_i = rydberg_interaction(coordinates2)
+
+
+def f1(p, t):
+    return p * np.sin(t) * (t - 1)
+
+
+def f2(p, t):
+    return p[0] * np.cos(p[1] * t**2)
+
+
+# amplitude function must be 0 at start and end for hardware
+def amp(p, t):
+    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+    return qml.pulse.rect(f, windows=[0.1, 1.7])
+
+
+params1 = 1.2
+params2 = [3.4, 5.6]
+params_amp = [2.5, 0.9, 0.3]
+
+DEV_ATTRIBUTES = [(BraketAquilaDevice, "Aquila", "braket.aws.aquila"),
+                  (BraketLocalQubitDevice, "RydbergAtomSimulator", "braket.local.aquila")]
+
+dev_hw = BraketAquilaDevice(wires=3)
+dev_sim = BraketLocalQubitDevice(wires=3, shots=17)
+
+
+def dummy_ahs_program():
+
+    # amplutide 10 for full duration
+    amplitude = TimeSeries()
+    amplitude.put(0, 10)
+    amplitude.put(4e-6, 10)
+
+    # phase and detuning 0 for full duration
+    phi = TimeSeries().put(0, 0).put(4e-6, 0)
+    detuning = TimeSeries().put(0, 0).put(4e-6, 0)
+
+    # Hamiltonian
+    H = DrivingField(amplitude, phi, detuning)
+
+    # register
+    register = AtomArrangement()
+    for [x, y] in coordinates2:
+        register.add([x*1e-6, y*1e-6])
+
+    ahs_program = AnalogHamiltonianSimulation(
+        hamiltonian=H,
+        register=register
+    )
+
+    return ahs_program
+
+# dummy data classes for testing result processing
+@dataclass
+class Status:
+    value: str
+
+
+@dataclass
+class DummyMeasurementResult:
+    status: Status
+    pre_sequence: np.array
+    post_sequence: np.array
+
+
+DUMMY_RESULTS = [(DummyMeasurementResult(Status('Success'), np.array([1]), np.array([1])), np.array([0])),
+           (DummyMeasurementResult(Status('Success'), np.array([1]), np.array([0])), np.array([1])),
+           (DummyMeasurementResult(Status('Success'), np.array([0]), np.array([0])), np.array([np.NaN])),
+           (DummyMeasurementResult(Status('Failure'), np.array([1]), np.array([1])), np.array([np.NaN])),
+           (DummyMeasurementResult(Status('Success'), np.array([1, 1, 0]), np.array([1, 0, 0])), np.array([0, 1, np.NaN])),
+           (DummyMeasurementResult(Status('Success'), np.array([1, 1]), np.array([0, 0])), np.array([1, 1])),
+           (DummyMeasurementResult(Status('Success'), np.array([0, 1]), np.array([0, 0])), np.array([np.NaN, 1])),
+           (DummyMeasurementResult(Status('Failure'), np.array([1, 1]), np.array([1, 1])), np.array([np.NaN, np.NaN]))
+           ]
+
+
+class TestBraketAhsDevice:
+    """Tests that behaviour defined for both the LocalSimulator and the
+    Aquila hardware in the base device work as expected"""
+
+    @pytest.mark.parametrize("dev_cls, device_name", "short_name", DEV_ATTRIBUTES)
+    def test_initialization(self, dev_cls, name, short_name):
+        """Test the device initializes with the expected attributes"""
+
+        dev = dev_cls(wires=3)
+
+        assert dev._device.name == name
+        assert dev.short_name == short_name
+        assert dev.shots == 100
+        assert dev.ahs_program is None
+        assert dev.samples is None
+        assert dev.pennylane_requires == ">=0.29.0"
+        assert dev.operations == {"ParametrizedEvolution"}
+
+    @pytest.mark.parametrize("dev_cls, shots", [(BraketAquilaDevice, 1000),
+                                                (BraketAquilaDevice, 2),
+                                                (BraketLocalQubitDevice, 1000),
+                                                (BraketLocalQubitDevice, 2)])
+    def test_setting_shots(self, dev_cls, shots):
+        """Test that setting shots changes number of shots from default (100)"""
+        dev = dev_cls(wires=3, shots=shots)
+        assert dev.shots == shots
+
+        if dev_cls == BraketLocalQubitDevice:
+            global_drive = rydberg_drive(amp, f1, 2, wires=[0, 1, 2])
+            ts = jnp.array([0.0, 1.75])
+            params = [params_amp, params1]
+
+            @qml.qnode(dev)
+            def circuit(p):
+                qml.evolve(Hd + global_drive)(p, ts)
+                return qml.sample()
+
+            assert len(circuit(params)) == shots
+
+    @pytest.mark.parametrize("dev_cls, wires", [(BraketAquilaDevice, 2),
+                                                (BraketAquilaDevice, [0, 2, 4]),
+                                                (BraketLocalQubitDevice, [0, 'a', 7]),
+                                                (BraketLocalQubitDevice, 7)])
+    def test_setting_wires(self, dev_cls, wires):
+        """Test setting wires"""
+        dev = dev_cls(wires=wires)
+
+        if wires is int:
+            assert len(dev.wires) == wires
+            assert wires.labels == tuple(i for i in range(wires))
+        else:
+            assert len(wires) == len(dev.wires)
+            assert wires.labels == tupe(wires)
+
+    def test_apply(self, dev_cls, operations):
+        """Test that apply creates and saves an ahs_program and samples as expected"""
+        pass
+
+    def test_create_ahs_program(self, dev_cls, evolution):
+        """Test creating an AnalogueHamiltonianSimulation from an evolution operator"""
+        pass
+
+    def test_generate_samples(self):
+        """Test that generate_samples creates a list of arrays with the expected shape for the task run"""
+        ahs_program = dummy_ahs_program()
+
+        # correspondance between number of device wires and coordinates is checked in PL when creating the Hamiltonian
+        # since this is done manually for the unit test, we confirm the values used for the test are valid here
+        assert len(ahs_program.register.coordinate_list(0)) == dev_sim.wires
+
+        task = dev_sim._run_task(ahs_program)
+
+        dev_sim.samples = task.result()
+
+        samples = dev_sim.generate_samples()
+
+        assert len(samples) == 17
+        assert len(samples[0]) == len(dev_sim.wires)
+        assert samples[0] == np.zeros(len(dev_sim.wires))
+        assert isinstance(samples[0], np.array)
+
+    @pytest.mark.parametrize("dev", [dev_hw, dev_sim])
+    def test_validate_operations_multiple_operators(self, dev):
+        """Test that an error is raised if there are multiple operators"""
+
+        H1 = rydberg_drive(amp, f1, 2, wires=[0, 1, 2])
+        op1 = qml.evolve(H_i + H1)
+        op2 = qml.evolve(H_i + H1)
+
+        with pytest.warns("Support for multiple ParametrizedEvolution operators"):
+            dev._validate_operations([op1, op2])
+
+    @pytest.mark.parametrize("dev", [dev_hw, dev_sim])
+    def test_validate_operations_not_rydberg_hamiltonian(self, dev):
+        """Test that an error is raised if the ParametrizedHamiltonian on the operator
+        is not a RydbergHamiltonian and so does not contain pulse upload information"""
+
+        H1 = 2 * qml.PauliX(0) + f1 * qml.PauliY(1)
+        op1 = qml.evolve(H1)
+
+        with pytest.warns("Expected a RydbergHamiltonian instance"):
+            dev._validate_operations([op1])
+
+    @pytest.mark.parametrize("dev, coordinates", [(dev_hw, coordinates1),
+                                     (dev_hw, coordinates2),
+                                     (dev_sim, coordinates1),
+                                     (dev_sim, coordinates2)])
+    def test_create_register(self, dev, coordinates):
+        """Test that an AtomArrangement with the expected coordinates is created
+        and stored on the device"""
+        reg = dev._create_register(coordinates)
+
+        coordinates_from_reg = [[x*1e6, y*1e6] for x, y in zip(dev.register.coordinate_list(0), dev.register.coordinate_list(1))]
+
+        assert isinstance(reg, AtomArrangement)
+        assert dev.register == reg
+        assert coordinates_from_reg == coordinates
+
+    def test_evaluate_pulses(self, dev_cls):
+        """Test that the callables describing pulses are partially evaluated"""
+        pass
+
+    @pytest.mark.parametrize("time_interval", [[1.5, 2.3], [0, 1.2], [0.111, 3.789]])
+    def test_get_sample_times(self, time_interval):
+        """Tests turning an array of [start, end] times into time set-points"""
+
+        times = dev_sim._get_sample_times()
+
+        num_points = len(times)
+        diffs = [times[i]-times[i-1] for i in range(1, num_points)]
+
+        # start and end times match but are in units of s and ns respectively
+        assert times[0] == time_interval[0]*1e-9
+        assert times[-1] == time_interval[1]*1e-9
+
+        # distances between points are close to but exceed 50ns
+        assert all(d > 50e-9 for d in diffs)
+        assert np.allclose(diffs, 50e-9, atol=5e-9)
+
+    def test_convert_to_time_series(self, dev_cls):
+        """Test creating a TimeSeries from pulse information and time set-points"""
+        pass
+
+    def test_convert_pulse_to_driving_field(self, dev_cls):
+        """Test that a pulse description (float or partially evaluated callable)
+        and array of time setpoints can be converted into a DrivingField"""
+        pass
+
+    @pytest.mark.parametrize("res, expected_output", DUMMY_RESULTS)
+    def test_result_to_sample_output(self, res, expected_output):
+        """Test function for converting the task results as returned by the
+        device into sample measurement results for PennyLane"""
+
+        output = dev_sim._result_to_sample_output(res)
+
+        assert isinstance(output, np.array)
+        assert len(output) == len(res.post_sequence)
+        assert output == expected_output
+
+
+class TestBraketAquilaDevice:
+    """Test functionality specific to the hardware device that can be tested
+    without running a task on the hardware"""
+
+    def test_hardware_capabilities(self):
+        """Test hardware capabilities can be retrieved"""
+
+        assert isinstance(dev.hardware_capabilities, dict)
+        assert 'rydberg' in dev.hardware_capabilities.keys()
+        assert 'lattice' in dev.hardware_capabilities.keys()
+
+    def test_validate_operations_multiple_drive_terms(self):
+        """Test that an error is raised if there are multiple drive terms on
+        the Hamiltonian"""
+        pulses = [RydbergPulse(3, 4, 5, [0, 1]), RydbergPulse(4, 6, 7, [1, 2])]
+
+        with pytest.warns("Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
+            dev_hw._validate_pulses(pulses)
+
+    @pytest.mark.parametrize("wires", [[0, 1, 2], [5, 6, 7, 8, 9], [0, 1, 2, 3, 6]])
+    def test_validate_pulse_is_global_drive(self, wires):
+        """Test that an error is raised if the pulse does not describe a global drive"""
+
+        pulse = RydbergPulse(3, 4, 5, wires)
+
+        with pytest.warns("Only global drive is currently supported on hardware"):
+            dev_hw._validate_pulses([pulse])
+
+
+class TestLocalAquilaDevice:
+    """Test functionality specific to the local simulator device"""
+
+    def test_validate_operations_multiple_drive_terms(self):
+        """Test that an error is raised if there are multiple drive terms on
+        the Hamiltonian"""
+        pulses = [RydbergPulse(3, 4, 5, [0, 1]), RydbergPulse(4, 6, 7, [1, 2])]
+
+        with pytest.warns("Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
+            dev_sim._validate_pulses(pulses)
+
+    @pytest.mark.parametrize("wires", [[0, 1, 2], [5, 6, 7, 8, 9], [0, 1, 2, 3, 6]])
+    def test_validate_pulse_is_global_drive(self, wires):
+        """Test that an error is raised if the pulse does not describe a global drive"""
+
+        pulse = RydbergPulse(3, 4, 5, wires)
+
+        with pytest.warns("Only global drive is currently supported"):
+            dev_sim._validate_pulses([pulse])
+
+    def test_run_task(self):
+        ahs_program = dummy_ahs_program()
+
+        task = dev_sim._run_task(ahs_program)
+
+        assert isinstance(task, LocalQuantumTask)
+        assert len(task.result().measurements) == 17  # dev_sim takes 17 shots
+        assert isinstance(task.result().measurements[0], ShotResult)

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -478,8 +478,8 @@ class TestLocalAquilaDevice:
         with pytest.raises(NotImplementedError, match="Multiple pulses in a Rydberg Hamiltonian are not currently supported"):
             dev_sim._validate_pulses(pulses)
 
-    @pytest.mark.parametrize("pulse_wires, dev_wires, res", [([0, 1, 2], [0, 1, 2, 3], 'error'), # subset
-                                                             ([5, 6, 7, 8, 9], [4, 5, 6, 7, 8], 'error'), # mismatch
+    @pytest.mark.parametrize("pulse_wires, dev_wires, res", [([0, 1, 2], [0, 1, 2, 3], 'error'),  # subset
+                                                             ([5, 6, 7, 8, 9], [4, 5, 6, 7, 8], 'error'),  # mismatch
                                                              ([0, 1, 2, 3, 6], [1, 2, 3], 'error'),
                                                              ([0, 1, 2], [0, 1, 2], 'success')])
     def test_validate_pulse_is_global_drive(self, pulse_wires, dev_wires, res):

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -12,7 +12,7 @@ from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import ShotR
 import pennylane as qml
 import numpy as np
 from pennylane.pulse.rydberg_hamiltonian import RydbergHamiltonian, RydbergPulse, rydberg_drive, rydberg_interaction
-from jax import numpy as jnp
+#from jax import numpy as jnp
 from dataclasses import dataclass
 from functools import partial
 
@@ -34,7 +34,7 @@ def f2(p, t):
 
 # realistic amplitude function (0 at start and end for hardware)
 def amp(p, t):
-    f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+    f = p[0] * np.exp(-(t-p[1])**2/(2*p[2]**2))
     return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
 
 

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -20,7 +20,7 @@ from functools import partial
 coordinates1 = [[0, 0], [0, 5], [5, 0], [10, 5], [5, 10], [10, 10]]
 wires1 = [1, 6, 0, 2, 4, 3]
 
-coordinates2 = [[0, 0], [5.5, 0.0], [2.75, 4.763139720814412]]
+coordinates2 = [[0, 0], [5.5, 0.0], [2.75, 4.763139720814412]] #in µm
 H_i = rydberg_interaction(coordinates2)
 
 

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -61,12 +61,13 @@ params_amp = [2.5, 0.9, 0.3]
 
 HAMILTONIANS_AND_PARAMS = [(H_i + rydberg_drive(amplitude=4, phase=1, detuning=3, wires=[0, 1, 2]), []),
                 (H_i + rydberg_drive(amplitude=amp, phase=1, detuning=2, wires=[0, 1, 2]), [params_amp]),
-                # (H_i + rydberg_drive(amplitude=2, phase=f1, detuning=2, wires=[0, 1, 2]), [params1]),
+                (H_i + rydberg_drive(amplitude=2, phase=f1, detuning=2, wires=[0, 1, 2]), [params1]),
                 (H_i + rydberg_drive(amplitude=amp, phase=1, detuning=f2, wires=[0, 1, 2]), [params_amp, params2]),
-                # (H_i + rydberg_drive(amplitude=4, phase=f2, detuning=f1, wires=[0, 1, 2]), [params2, params1]),
-                # (H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=4, wires=[0, 1, 2]), [params_amp, params2]),
-                # (H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=f1, wires=[0, 1, 2]), [params_amp, params2, params1])
+                (H_i + rydberg_drive(amplitude=4, phase=f2, detuning=f1, wires=[0, 1, 2]), [params2, params1]),
+                (H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=4, wires=[0, 1, 2]), [params_amp, params2]),
+                (H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=f1, wires=[0, 1, 2]), [params_amp, params2, params1])
                 ]
+
 
 DEV_ATTRIBUTES = [(BraketAquilaDevice, "Aquila", "braket.aws.aquila"),
                   (BraketLocalAquilaDevice, "RydbergAtomSimulator", "braket.local.aquila")]
@@ -162,10 +163,11 @@ class TestBraketAhsDevice:
         dev = dev_cls(wires=3, shots=shots)
         assert dev.shots == shots
 
-    def test_shots_is_none_raises_error(self):
-        """Test that setting shots changes number of shots from default (100)"""
-        with pytest.raises(RuntimeError, match="Number of shots must be defined"):
-            BraketLocalAquilaDevice(wires=3, shots=None)
+    @pytest.mark.parametrize("shots", [0, None])
+    def test_no_shots_raises_error(self, shots):
+        """Test that an error is raised if shots are set to 0 or None"""
+        with pytest.raises(RuntimeError, match="This device requires shots"):
+            BraketLocalAquilaDevice(wires=3, shots=shots)
 
     @pytest.mark.parametrize("dev_cls, wires", [(BraketAquilaDevice, 2),
                                                 (BraketAquilaDevice, [0, 2, 4]),

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import pytest
 import warnings
 
@@ -12,6 +25,7 @@ from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import ShotR
 import pennylane as qml
 import numpy as np
 
+from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
 from pennylane.pulse.rydberg import rydberg_interaction
 from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse, drive
 


### PR DESCRIPTION
This device facilitates the core functionality of converting a PennyLane circuit with a single `ParametrizedEvolution` operator describing a global drive on the system into a braket `DrivingField`, uploading, and acquiring results from either simulation or hardware.

Still to come in future PRs is adding local drive, and potentially some convenience functions or additional validation steps if we decide they would be useful.

This PR adds:

- a `BraketAhsDevice` base device that contains all the functionality that is shared between the AWS Rydberg atom simulator and the AWS Aquila hardware device
- a `BraketAquilaDevice` device that accesses the hardware backend
- a `BraketLocalAquilaDevice` that accesses the `LocalSimulator('braket_ahs')` backend

The difference between simulator and hardware is currently:

- `_validate_pulses` (currently not different but will be soon, once we add support for local drive pulses in simulation)
- `_run_task` (the hardware requires an extra step before running)
- the hardware device has a `hardware_capabilities` property that returns a dict of specifications for hardware

I've covered what came to mind in terms of tests, but am probably lacking some test coverage.