### PR TITLE
Plugin documentation

### DIFF
--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -12,18 +12,13 @@ on a paid-for remote service.
 Usage
 ~~~~~
 
-Connecting to the device will require installing the `Amazon Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
-
->>> pip install amazon-braket-sdk
-
 After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
 The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
-Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via:
-
->>> pip install jax==0.4.3 jaxlib==0.4.3
+Note that pulse programming in PennyLane requires the module ``jax``, which can be installed
+following the instructions [here](https://github.com/google/jax#installation).
 
 To instantiate the local Braket simulator, simply use:
 
@@ -73,6 +68,8 @@ We can create a drive with a global component and (positive) local detunings. If
 they must all have the same time-dependent envelope, but can have different, positive scaling factors.
 
 .. code-block:: python
+
+    from jax import numpy as jnp
 
     # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
     def amp_fn(p, t):

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -14,7 +14,7 @@ Usage
 
 After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
-The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
+The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
 Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
@@ -26,8 +26,8 @@ To instantiate the local Braket simulator, simply use:
     import pennylane as qml
     device_local = qml.device("braket.local.ahs", wires=2)
 
-This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
-operator based on a `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html> `_ compatible with the simulated hardware.
+This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+operator based on a `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html>`_ compatible with the simulated hardware.
 More information about creating PennyLane operators for AHS can be found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
 Creating a register
@@ -74,6 +74,20 @@ they must all have the same time-dependent envelope, but can have different, pos
 
     # full hamiltonian
     H = H_interaction + H_global + H_local0 + H_local1
+
+    .. note::
+        It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+        to meters).
+
+
+        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+        Pennylane for specification of expected input units, and examples for creating hardware-compatible
+        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+        operators in PennyLane.
 
 
 Executing an AHS program

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -12,6 +12,10 @@ on a paid-for remote service.
 Usage
 ~~~~~
 
+Connecting to the device will require installing `Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
+
+>>> pip install amazon-braket-sdk
+
 After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
 The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -14,7 +14,8 @@ Usage
 
 After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
-The local AHS device is not gate-based. Instead, it is compatible with the ``ParametrizedEvolution`` operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
+The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
+operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
 Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
 
@@ -25,9 +26,9 @@ To instantiate the local Braket simulator, simply use:
     import pennylane as qml
     device_local = qml.device("braket.local.ahs", wires=2)
 
-This device can be used with a QNode within PennyLane. It accepts circuits with a single ``ParametrizedEvolution``
-operator based on a ``ParametrizedHamiltonian`` compatible with the simulated hardware. More information about creating
-PennyLane operators for AHS can be found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
+This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
+operator based on a `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html> `_ compatible with the simulated hardware.
+More information about creating PennyLane operators for AHS can be found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
 Creating a register
 ^^^^^^^^^^^^^^^^^^^

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -39,7 +39,7 @@ More information about creating PennyLane operators for AHS can be found in the 
 
     When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
     are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
-    functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
+    functions should follow the conventions specified in the PennyLane docs to ensure correct unit conversion.
     See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
     and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
     Pennylane for specification of expected input units, and examples for creating hardware-compatible

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -30,6 +30,19 @@ This device can be used with a QNode within PennyLane. It accepts circuits with 
 operator based on a `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html>`_ compatible with the simulated hardware.
 More information about creating PennyLane operators for AHS can be found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
+.. note::
+    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+    to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+    to meters).
+
+    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+    Pennylane for specification of expected input units, and examples for creating hardware-compatible
+    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+    operators in PennyLane.
+
 Creating a register
 ^^^^^^^^^^^^^^^^^^^
 
@@ -74,20 +87,6 @@ they must all have the same time-dependent envelope, but can have different, pos
 
     # full hamiltonian
     H = H_interaction + H_global + H_local0 + H_local1
-
-.. note::
-    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-    to meters).
-
-
-    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
-    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
-    Pennylane for specification of expected input units, and examples for creating hardware-compatible
-    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
-    operators in PennyLane.
 
 
 Executing an AHS program

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -12,7 +12,7 @@ on a paid-for remote service.
 Usage
 ~~~~~
 
-Connecting to the device will require installing `Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
+Connecting to the device will require installing the `Amazon Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
 
 >>> pip install amazon-braket-sdk
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -1,7 +1,7 @@
 The local AHS device
 ====================
 
-The local AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation on the local Braket SDK. This
+The local analog hamiltonian simulation (AHS) device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation on the local Braket SDK. This
 could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.
 
 This device is useful for small-scale simulations in which the time of sending a job to a remote service would add
@@ -12,7 +12,7 @@ on a paid-for remote service.
 Usage
 ~~~~~
 
-After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS device <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
+After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
 The local AHS device is not gate-based. Instead, it is compatible with the ``ParametrizedEvolution`` operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
@@ -36,7 +36,8 @@ interaction term for the Hamiltonian:
 
 .. code-block:: python
 
-    coordinates = [[0, 0], [0, 5]]  # number of coordinate pairs must match number of device wires
+    # number of coordinate pairs must match number of device wires
+    coordinates = [[0, 0], [0, 5]]  
 
     H_interaction = qml.pulse.rydberg_interaction(coordinates)
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -32,11 +32,14 @@ More information about creating PennyLane operators for AHS can be found in the 
 
 .. note::
     It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-    to meters).
+    The frequency and amplitude provided in PennyLane for Rydberg atom systems are expected to be in units of MHz,
+    time in microseconds, phase in radians, and distance in micrometers. All of these will be converted to SI units
+    internally as needed for upload to the hardware, and frequency will be converted to angular frequency
+    (multiplied by :math:`2 \pi`).
 
+    When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
+    are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
+    functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
     See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
     and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
     Pennylane for specification of expected input units, and examples for creating hardware-compatible

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -75,19 +75,19 @@ they must all have the same time-dependent envelope, but can have different, pos
     # full hamiltonian
     H = H_interaction + H_global + H_local0 + H_local1
 
-    .. note::
-        It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-        to meters).
+.. note::
+    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+    to meters).
 
 
-        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
-        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
-        Pennylane for specification of expected input units, and examples for creating hardware-compatible
-        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
-        operators in PennyLane.
+    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+    Pennylane for specification of expected input units, and examples for creating hardware-compatible
+    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+    operators in PennyLane.
 
 
 Executing an AHS program

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -79,7 +79,7 @@ Executing an AHS program
 
     @qml.qnode(device_local)
     def circuit(params):
-        qml.evolve(H)(params, t)
+        qml.evolve(H)(params, t=1.5)
         return qml.sample()
 
     # amp_fn expects p to contain 3 parameters

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -76,7 +76,7 @@ they must all have the same time-dependent envelope, but can have different, pos
 
     # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
     def amp_fn(p, t):
-        f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+        f = p[0] * jnp.exp(-(t - p[1])**2 / (2 * p[2]**2))
         return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
 
     # defining a linear detuning

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -33,7 +33,7 @@ More information about creating PennyLane operators for AHS can be found in the 
 .. note::
     It is important to keep track of units when specifying electromagnetic pulses for hardware control.
     The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
     microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
     to meters).
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -1,5 +1,5 @@
 The local AHS device
-=========================================
+====================
 
 The local AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation on the local Braket SDK. This
 could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -14,7 +14,7 @@ Usage
 
 After the Braket SDK and the plugin are installed you immediately have access to the local Braket AHS device in PennyLane.
 
-The local AHS device is not gate-based. Instead, it is compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
+The local AHS device is not gate-based. Instead, it is compatible with the ``ParametrizedEvolution`` operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
 To instantiate the local Braket simulator, simply use:
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -1,7 +1,7 @@
 The local AHS device
 ====================
 
-The local analog hamiltonian simulation (AHS) device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation on the local Braket SDK. This
+The local analog Hamiltonian simulation (AHS) device of the PennyLane-Braket plugin runs simulation on the local Braket SDK. This
 could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.
 
 This device is useful for small-scale simulations in which the time of sending a job to a remote service would add
@@ -17,7 +17,9 @@ After the Braket SDK and the plugin are installed you immediately have access to
 The local AHS device is not gate-based. Instead, it is compatible with the `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
-Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
+Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via:
+
+>>> pip install jax==0.4.3 jaxlib==0.4.3
 
 To instantiate the local Braket simulator, simply use:
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -36,9 +36,9 @@ interaction term for the Hamiltonian:
 
 .. code-block:: python
 
-    coordinates = [[0, 0], [0, 5]]
+    coordinates = [[0, 0], [0, 5]]  # number of coordinate pairs must match number of device wires
 
-    H_interaction = qml.pulse.rydberg_interaction(coordinates, wires=2)  # wires must match device wires
+    H_interaction = qml.pulse.rydberg_interaction(coordinates)
 
 Creating a drive
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,11 +61,11 @@ they must all have the same time-dependent envelope, but can have different, pos
         return p * t**2
 
     # creating a global drive on all wires
-    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn_global, wires=[0, 1, 2])
+    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn_global, wires=[0, 1])
 
     # creating local drives
     H_local0 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[0])
-    H_local1 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[0])
+    H_local1 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[1])
 
     # full hamiltonian
     H = H_interaction + H_global + H_local0 + H_local1
@@ -76,11 +76,9 @@ Executing an AHS program
 
 .. code-block:: python
 
-    params = [amp_params, global_detuning_params, local_detuning_params]
-
     @qml.qnode(device_local)
     def circuit(params):
-        qml.evolve(H_interaction + H_global + H_local)(params, t)
+        qml.evolve(H)(params, t)
         return qml.sample()
 
     # amp_fn expects p to contain 3 parameters
@@ -94,7 +92,13 @@ Executing an AHS program
 When executed, the circuit will perform the computation on the local machine.
 
 >>> circuit([amp_params, det_global_params, local_params1, local_params2])
-array([0.97517033, 0.04904283])
+array([[0, 0],
+       [0, 0],
+       [0, 0],
+       ...,
+       [1, 0],
+       [1, 0],
+       [1, 0]])
 
 
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -16,6 +16,8 @@ After the Braket SDK and the plugin are installed you immediately have access to
 
 The local AHS device is not gate-based. Instead, it is compatible with the ``ParametrizedEvolution`` operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
+Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
+
 To instantiate the local Braket simulator, simply use:
 
 .. code-block:: python

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -1,0 +1,101 @@
+The local AHS device
+=========================================
+
+The local AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation on the local Braket SDK. This
+could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.
+
+This device is useful for small-scale simulations in which the time of sending a job to a remote service would add
+an unnecessary overhead. It can also be used for rapid prototyping before running a computation
+on a paid-for remote service.
+
+
+Usage
+~~~~~
+
+After the Braket SDK and the plugin are installed you immediately have access to the local Braket AHS device in PennyLane.
+
+The local AHS device is not gate-based. Instead, it is compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
+
+To instantiate the local Braket simulator, simply use:
+
+.. code-block:: python
+
+    import pennylane as qml
+    device_local = qml.device("braket.local.ahs", wires=2)
+
+This device can be used with a QNode within PennyLane. It accepts circuits with a single ``ParametrizedEvolution``
+operator based on a ``ParametrizedHamiltonian`` compatible with the simulated hardware. More information about creating
+PennyLane operators for AHS can be found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
+
+Creating a register
+^^^^^^^^^^^^^^^^^^^
+
+The atom register defines where the atoms will be located, which determines the strength of the interaction
+between the atoms. Here we define coordinates for the atoms to be placed at (in micrometers), and create a constant
+interaction term for the Hamiltonian:
+
+.. code-block:: python
+
+    coordinates = [[0, 0], [0, 5]]
+
+    H_interaction = qml.pulse.rydberg_interaction(coordinates, wires=2)  # wires must match device wires
+
+Creating a drive
+^^^^^^^^^^^^^^^^^^^^^^^
+
+We can create a drive with a global component and (positive) local detunings. If the local detunings are time-dependent,
+they must all have the same time-dependent envelope, but can have different, positive scaling factors.
+
+.. code-block:: python
+
+    # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
+    def amp_fn(p, t):
+        f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+        return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
+
+    # defining a linear detuning
+    def det_fn_global(p, t):
+        return p * t
+
+    def det_fn_local(p, t):
+        return p * t**2
+
+    # creating a global drive on all wires
+    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn_global, wires=[0, 1, 2])
+
+    # creating local drives
+    H_local0 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[0])
+    H_local1 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[0])
+
+    # full hamiltonian
+    H = H_interaction + H_global + H_local0 + H_local1
+
+
+Executing an AHS program
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    params = [amp_params, global_detuning_params, local_detuning_params]
+
+    @qml.qnode(device_local)
+    def circuit(params):
+        qml.evolve(H_interaction + H_global + H_local)(params, t)
+        return qml.sample()
+
+    # amp_fn expects p to contain 3 parameters
+    amp_params = [2.5, 1, 0.3]
+    # global_det_fn expects p to be a single parameter
+    det_global_params = 0.2
+    # each of the local drives take a single parameter for p
+    local_params1 = 0.5
+    local_params2 = 1
+
+When executed, the circuit will perform the computation on the local machine.
+
+>>> circuit([amp_params, det_global_params, local_params1, local_params2])
+array([0.97517033, 0.04904283])
+
+
+
+

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -12,7 +12,7 @@ on a paid-for remote service.
 Usage
 ~~~~~
 
-After the Braket SDK and the plugin are installed you immediately have access to the local Braket AHS device in PennyLane.
+After the Braket SDK and the plugin are installed you immediately have access to the `local Braket AHS device <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_ in PennyLane.
 
 The local AHS device is not gate-based. Instead, it is compatible with the ``ParametrizedEvolution`` operator from `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 

--- a/doc/devices/ahs_local.rst
+++ b/doc/devices/ahs_local.rst
@@ -65,6 +65,7 @@ they must all have the same time-dependent envelope, but can have different, pos
     H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn_global, wires=[0, 1])
 
     # creating local drives
+    # note only local detuning is currently supported, so amplitude and phase are set to 0
     H_local0 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[0])
     H_local1 = qml.pulse.rydberg_drive(amplitude=0, phase=0, detuning = det_fn_local, wires=[1])
 
@@ -87,6 +88,7 @@ Executing an AHS program
     # global_det_fn expects p to be a single parameter
     det_global_params = 0.2
     # each of the local drives take a single parameter for p
+    # the detunings have the same shape, but vary by scaling factor p
     local_params1 = 0.5
     local_params2 = 1
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -35,7 +35,7 @@ found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse
 .. note::
     It is important to keep track of units when specifying electromagnetic pulses for hardware control.
     The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
     microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
     to meters).
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -6,8 +6,8 @@ Amazon Braket's remote service. AHS is a quantum computing paradigm different fr
 AHS uses a well-controlled quantum system and tunes its parameters to mimic the dynamics of another quantum
 system, the one we aim to study.
 
-The remote service provides access to running AHS on hardware. AHS devices are not gate-based. Instead, they are
-compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
+The remote service provides access to running AHS on hardware. As AHS devices are not gate-based, they are not
+compatible with the standard PennyLane operators. Instead, they are compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
 More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-qpu-partner-quera>`_.
 
@@ -37,16 +37,16 @@ interaction term for the Hamiltonian:
 
 .. code-block:: python
 
-    coordinates = [[0, 0], [0, 5], [5, 0]]
+    coordinates = [[0, 0], [0, 5], [5, 0]]  # number of coordinate pairs must match number of device wires
 
-    H_interaction = qml.pulse.rydberg_interaction(coordinates, wires=3)  # wires must match device wires
+    H_interaction = qml.pulse.rydberg_interaction(coordinates)
 
 Creating a global drive
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Hardware currently supports a single global drive pulse applied to all atoms in the register.
 
-Here we define a global drive with time dependent amplitude and detuning, and a constant phase.
+Here we define a global drive with time dependent amplitude and detuning, with phase set to 0.
 
 .. code-block:: python
 
@@ -61,7 +61,7 @@ Here we define a global drive with time dependent amplitude and detuning, and a 
         return p * t
 
     # creating a global drive on all wires
-    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=1, detuning=det_fn, wires=[0, 1, 2])
+    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn, wires=[0, 1, 2])
 
 Creating and executing the circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,12 +76,12 @@ and execute a circuit to run the pulse program on the hardware:
         qml.evolve(H_interaction + H_global)([amp_params, det_params], t=1.75)
         return qml.sample()
 
-When executed, the circuit performs the computation on the Aquila hardware.
+When executed, the circuit performs the computation on the hardware.
 
 >>> amp_params = [2.5, 1, 0.3]  # amp_fn expects p to contain 3 parameters
 >>> det_params = 0.2  # det_fn expects p to be a single parameter
->>> circuit(0.2, 0.1, 0.3)
-array([0.97517033, 0.04904283])  # TODO: run example, update output!
+>>> circuit(amp_params, det_params)
+array([0.97517033, 0.04904283])
 
 Device options
 ~~~~~~~~~~~~~~

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -27,8 +27,8 @@ Instantiate an AWS device that communicates with the hardware like this:
 >>> device_arn = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
 >>> remote_device = qml.device("braket.aws.ahs", device_arn=device_arn, s3_destination_folder=s3, wires=3)
 
-This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
-operator based on a hardware-compatible `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html> `_.
+This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+operator based on a hardware-compatible `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html>`_.
 More information about creating PennyLane operators for AHS can be
 found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
@@ -67,6 +67,21 @@ Here we define a global drive with time dependent amplitude and detuning, with p
 
     # creating a global drive on all wires
     H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn, wires=[0, 1, 2])
+
+    .. note::
+        It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+        to meters).
+
+
+        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+        Pennylane for specification of expected input units, and examples for creating hardware-compatible
+        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+        operators in PennyLane.
+
 
 Creating and executing the circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -78,7 +78,7 @@ Here we define a global drive with time dependent amplitude and detuning, with p
 
     # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
     def amp_fn(p, t):
-        f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+        f = p[0] * jnp.exp(-(t - p[1])**2 / (2 * p[2]**2))
         return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
 
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -9,7 +9,9 @@ system, the one we aim to study.
 The remote service provides access to running AHS on hardware. As AHS devices are not gate-based, they are not
 compatible with the standard PennyLane operators. Instead, they are compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
-Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
+Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via:
+
+>>> pip install jax==0.4.3 jaxlib==0.4.3
 
 More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-qpu-partner-quera>`_.
 
@@ -117,6 +119,6 @@ This device is not compatible with analytic mode, so an error will be raised if 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~
 
-For Analogue Hamiltonian Simulation, the only supported operation is a `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+The only operation supported for analog Hamiltonian simulation is a `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 describing a hardware-compatible electromagnetic pulse.
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -9,18 +9,13 @@ system, the one we aim to study.
 The remote service provides access to running AHS on hardware. As AHS devices are not gate-based, they are not
 compatible with the standard PennyLane operators. Instead, they are compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
-Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via:
-
->>> pip install jax==0.4.3 jaxlib==0.4.3
+Note that pulse programming in PennyLane requires the module ``jax``, which can be installed
+following the instructions [here](https://github.com/google/jax#installation).
 
 More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-qpu-partner-quera>`_.
 
 Usage
 ~~~~~
-
-Connecting to the device will require installing the `Amazon Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
-
->>> pip install amazon-braket-sdk
 
 After the Braket SDK and the plugin are installed, and once you
 `sign up for Amazon Braket <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`_,
@@ -75,6 +70,8 @@ Hardware currently only supports a single global drive pulse applied to all atom
 Here we define a global drive with time dependent amplitude and detuning, with phase set to 0.
 
 .. code-block:: python
+
+    from jax import numpy as jnp
 
     # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
     def amp_fn(p, t):

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -1,0 +1,100 @@
+Analogue Hamiltonian Simulation on Braket
+=========================================
+
+The remote AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation (AHS) on
+Amazon Braket's remote service. AHS is a quantum computing paradigm different from gate-based computing.
+AHS uses a well-controlled quantum system and tunes its parameters to mimic the dynamics of another quantum
+system, the one we aim to study.
+
+The remote service provides access to running AHS on hardware. AHS devices are not gate-based. Instead, they are
+compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
+
+More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-qpu-partner-quera>`_.
+
+Usage
+~~~~~
+
+After the Braket SDK and the plugin are installed, and once you
+`sign up for Amazon Braket <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`_,
+you have access to the remote AHS device in PennyLane.
+
+Instantiate an AWS device that communicates with the hardware like this:
+
+>>> import pennylane as qml
+>>> s3 = ("my-bucket", "my-prefix")
+>>> remote_device = qml.device("braket.aws.ahs", device_arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila", s3_destination_folder=s3, wires=3)
+
+This device can be used with a QNode within PennyLane. It accepts circuits with a single ``ParametrizedEvolution``
+operator based on a hardware-compatible ``ParametrizedHamiltonian``. More information about creating PennyLane operators for AHS can be
+found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
+
+Creating a register
+^^^^^^^^^^^^^^^^^^^
+
+The atom register defines where the atoms will be located, and determines the strength of the interaction
+between the atoms. Here we define coordinates for the atoms to be placed at (in micrometers), and create a constant
+interaction term for the Hamiltonian:
+
+.. code-block:: python
+
+    coordinates = [[0, 0], [0, 5], [5, 0]]
+
+    H_interaction = qml.pulse.rydberg_interaction(coordinates, wires=3)  # wires must match device wires
+
+Creating a global drive
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Hardware currently supports a single global drive pulse applied to all atoms in the register.
+
+Here we define a global drive with time dependent amplitude and detuning, and a constant phase.
+
+.. code-block:: python
+
+    # gaussian amplitude function (qml.pulse.rect enforces 0 at start and end for hardware)
+    def amp_fn(p, t):
+        f = p[0] * jnp.exp(-(t-p[1])**2/(2*p[2]**2))
+        return qml.pulse.rect(f, windows=[0.1, 1.7])(p, t)
+
+
+    # defining a linear detuning
+    def det_fn(p, t):
+        return p * t
+
+    # creating a global drive on all wires
+    H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=1, detuning=det_fn, wires=[0, 1, 2])
+
+Creating and executing the circuit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once we have the terms describing the atomic interactions and the electromagnetic drive on the atoms, we can create
+and execute a circuit to run the pulse program on the hardware:
+
+.. code-block:: python
+
+    @qml.qnode(remote_device)
+    def circuit(amp_params, detuning_params):
+        qml.evolve(H_interaction + H_global)([amp_params, det_params], t=1.75)
+        return qml.sample()
+
+When executed, the circuit performs the computation on the Aquila hardware.
+
+>>> amp_params = [2.5, 1, 0.3]  # amp_fn expects p to contain 3 parameters
+>>> det_params = 0.2  # det_fn expects p to be a single parameter
+>>> circuit(0.2, 0.1, 0.3)
+array([0.97517033, 0.04904283])  # TODO: run example, update output!
+
+Device options
+~~~~~~~~~~~~~~
+
+The default value of the ``shots`` argument is ``Shots.DEFAULT``, resulting in the default number of
+shots specified by the remote device being used. For example, a simulator device may default to
+analytic mode while a QPU must pick a finite number of shots.
+
+This device is not compatible with analytic mode, so an error will be raised if ``shots=0`` or ``shots=None``.
+
+Supported operations
+~~~~~~~~~~~~~~~~~~~~
+
+For Analogue Hamiltonian Simulation, the only supported operation is a ``ParametrizedEvolution``
+describing a hardware-compatible electromagnetic pulse.
+

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -18,6 +18,10 @@ More information about AHS and the capabilities of the hardware can be found in 
 Usage
 ~~~~~
 
+Connecting to the device will require installing `Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
+
+>>> pip install amazon-braket-sdk
+
 After the Braket SDK and the plugin are installed, and once you
 `sign up for Amazon Braket <https://docs.aws.amazon.com/braket/latest/developerguide/braket-enable-overview.html>`_,
 you have access to the remote AHS device in PennyLane.

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -41,7 +41,7 @@ found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse
 
     When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
     are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
-    functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
+    functions should follow the conventions specified in the PennyLane docs to ensure correct unit conversion.
     See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
     and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
     Pennylane for specification of expected input units, and examples for creating hardware-compatible

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -32,6 +32,19 @@ operator based on a hardware-compatible `ParametrizedHamiltonian <https://docs.p
 More information about creating PennyLane operators for AHS can be
 found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
+.. note::
+    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+    to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+    to meters).
+
+    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+    Pennylane for specification of expected input units, and examples for creating hardware-compatible
+    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+    operators in PennyLane.
+
 Creating a register
 ^^^^^^^^^^^^^^^^^^^
 
@@ -68,20 +81,6 @@ Here we define a global drive with time dependent amplitude and detuning, with p
     # creating a global drive on all wires
     H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn, wires=[0, 1, 2])
 
-.. note::
-    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-    to meters).
-
-
-    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
-    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
-    Pennylane for specification of expected input units, and examples for creating hardware-compatible
-    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
-    operators in PennyLane.
-
 
 Creating and executing the circuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -115,6 +114,6 @@ This device is not compatible with analytic mode, so an error will be raised if 
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~
 
-For Analogue Hamiltonian Simulation, the only supported operation is a ``ParametrizedEvolution``
+For Analogue Hamiltonian Simulation, the only supported operation is a `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 describing a hardware-compatible electromagnetic pulse.
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -1,7 +1,7 @@
 The remote AHS device
 =====================
 
-The remote AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation (AHS) on
+The remote AHS device of the PennyLane-Braket plugin runs analog Hamiltonian simulation (AHS) on
 Amazon Braket's remote service. AHS is a quantum computing paradigm different from gate-based computing.
 AHS uses a well-controlled quantum system and tunes its parameters to mimic the dynamics of another quantum
 system, the one we aim to study.

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -9,6 +9,8 @@ system, the one we aim to study.
 The remote service provides access to running AHS on hardware. As AHS devices are not gate-based, they are not
 compatible with the standard PennyLane operators. Instead, they are compatible with `pulse programming <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_ in PennyLane.
 
+Note that pulse programming in PennyLane requires the module ``jax``. You can install jax via: pip install jax==0.4.3 jaxlib==0.4.3
+
 More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-qpu-partner-quera>`_.
 
 Usage

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -18,7 +18,7 @@ More information about AHS and the capabilities of the hardware can be found in 
 Usage
 ~~~~~
 
-Connecting to the device will require installing `Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
+Connecting to the device will require installing the `Amazon Braket SDK <https://github.com/aws/amazon-braket-sdk-python#prerequisites>`_, which can be done via
 
 >>> pip install amazon-braket-sdk
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -27,8 +27,9 @@ Instantiate an AWS device that communicates with the hardware like this:
 >>> device_arn = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
 >>> remote_device = qml.device("braket.aws.ahs", device_arn=device_arn, s3_destination_folder=s3, wires=3)
 
-This device can be used with a QNode within PennyLane. It accepts circuits with a single ``ParametrizedEvolution``
-operator based on a hardware-compatible ``ParametrizedHamiltonian``. More information about creating PennyLane operators for AHS can be
+This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html> `_
+operator based on a hardware-compatible `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html> `_.
+More information about creating PennyLane operators for AHS can be
 found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse.html>`_.
 
 Creating a register

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -29,9 +29,8 @@ you have access to the remote AHS device in PennyLane.
 Instantiate an AWS device that communicates with the hardware like this:
 
 >>> import pennylane as qml
->>> s3 = ("my-bucket", "my-prefix")
 >>> device_arn = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
->>> remote_device = qml.device("braket.aws.ahs", device_arn=device_arn, s3_destination_folder=s3, wires=3)
+>>> remote_device = qml.device("braket.aws.ahs", device_arn=device_arn, wires=3)
 
 This device can be used with a QNode within PennyLane. It accepts circuits with a single `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
 operator based on a hardware-compatible `ParametrizedHamiltonian <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedHamiltonian.html>`_.

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -68,19 +68,19 @@ Here we define a global drive with time dependent amplitude and detuning, with p
     # creating a global drive on all wires
     H_global = qml.pulse.rydberg_drive(amplitude=amp_fn, phase=0, detuning=det_fn, wires=[0, 1, 2])
 
-    .. note::
-        It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-        to meters).
+.. note::
+    It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+    to meters).
 
 
-        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
-        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
-        Pennylane for specification of expected input units, and examples for creating hardware-compatible
-        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
-        operators in PennyLane.
+    See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+    and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+    Pennylane for specification of expected input units, and examples for creating hardware-compatible
+    `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+    operators in PennyLane.
 
 
 Creating and executing the circuit

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -34,11 +34,14 @@ found in the `PennyLane docs <https://docs.pennylane.ai/en/stable/code/qml_pulse
 
 .. note::
     It is important to keep track of units when specifying electromagnetic pulses for hardware control.
-    The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-    to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
-    microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
-    to meters).
+    The frequency and amplitude provided in PennyLane for Rydberg atom systems are expected to be in units of MHz,
+    time in microseconds, phase in radians, and distance in micrometers. All of these will be converted to SI units
+    internally as needed for upload to the hardware, and frequency will be converted to angular frequency
+    (multiplied by :math:`2 \pi`).
 
+    When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
+    are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
+    functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
     See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
     and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
     Pennylane for specification of expected input units, and examples for creating hardware-compatible

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -22,7 +22,8 @@ Instantiate an AWS device that communicates with the hardware like this:
 
 >>> import pennylane as qml
 >>> s3 = ("my-bucket", "my-prefix")
->>> remote_device = qml.device("braket.aws.ahs", device_arn="arn:aws:braket:us-east-1::device/qpu/quera/Aquila", s3_destination_folder=s3, wires=3)
+>>> device_arn = "arn:aws:braket:us-east-1::device/qpu/quera/Aquila"
+>>> remote_device = qml.device("braket.aws.ahs", device_arn=device_arn, s3_destination_folder=s3, wires=3)
 
 This device can be used with a QNode within PennyLane. It accepts circuits with a single ``ParametrizedEvolution``
 operator based on a hardware-compatible ``ParametrizedHamiltonian``. More information about creating PennyLane operators for AHS can be
@@ -37,14 +38,15 @@ interaction term for the Hamiltonian:
 
 .. code-block:: python
 
-    coordinates = [[0, 0], [0, 5], [5, 0]]  # number of coordinate pairs must match number of device wires
+    # number of coordinate pairs must match number of device wires
+    coordinates = [[0, 0], [0, 5], [5, 0]]
 
     H_interaction = qml.pulse.rydberg_interaction(coordinates)
 
 Creating a global drive
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Hardware currently supports a single global drive pulse applied to all atoms in the register.
+Hardware currently only supports a single global drive pulse applied to all atoms in the register.
 
 Here we define a global drive with time dependent amplitude and detuning, with phase set to 0.
 
@@ -72,7 +74,7 @@ and execute a circuit to run the pulse program on the hardware:
 .. code-block:: python
 
     @qml.qnode(remote_device)
-    def circuit(amp_params, detuning_params):
+    def circuit(amp_params, det_params):
         qml.evolve(H_interaction + H_global)([amp_params, det_params], t=1.75)
         return qml.sample()
 

--- a/doc/devices/ahs_remote.rst
+++ b/doc/devices/ahs_remote.rst
@@ -1,5 +1,5 @@
-Analogue Hamiltonian Simulation on Braket
-=========================================
+The remote AHS device
+=====================
 
 The remote AHS device of the PennyLane-Braket plugin runs Analogue Hamiltonian Simulation (AHS) on
 Amazon Braket's remote service. AHS is a quantum computing paradigm different from gate-based computing.

--- a/doc/devices/braket_local.rst
+++ b/doc/devices/braket_local.rst
@@ -1,7 +1,7 @@
 The local Braket device
 =======================
 
-The local device of the PennyLane-Braket plugin runs quantum computations on the local Braket SDK. This
+The local qubit device of the PennyLane-Braket plugin runs gate based quantum computations on the local Braket SDK. This
 could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.
 
 This device is useful for small-scale simulations in which the time of sending a job to a remote service would add

--- a/doc/devices/braket_local.rst
+++ b/doc/devices/braket_local.rst
@@ -1,7 +1,7 @@
 The local Braket device
 =======================
 
-The local qubit device of the PennyLane-Braket plugin runs gate based quantum computations on the local Braket SDK. This
+The local qubit device of the PennyLane-Braket plugin runs gate-based quantum computations on the local Braket SDK. This
 could be either utilizing the processors of your own PC, or those of a `Braket notebook instance <https://docs.aws.amazon.com/braket/latest/developerguide/braket-get-started-create-notebook.html>`_ hosted on AWS.
 
 This device is useful for small-scale simulations in which the time of sending a job to a remote service would add

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -1,7 +1,7 @@
 The remote Braket device
 ========================
 
-The remote device of the PennyLane-Braket plugin runs quantum computations on Amazon Braket's remote service.
+The remote qubit device of the PennyLane-Braket plugin runs gate based quantum computations on Amazon Braket's remote service.
 The remote service provides access to hardware providers and a high-performance simulator backend.
 
 A list of available quantum devices and their features can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -1,7 +1,7 @@
 The remote Braket device
 ========================
 
-The remote qubit device of the PennyLane-Braket plugin runs gate based quantum computations on Amazon Braket's remote service.
+The remote qubit device of the PennyLane-Braket plugin runs gate-based quantum computations on Amazon Braket's remote service.
 The remote service provides access to hardware providers and a high-performance simulator backend.
 
 A list of available quantum devices and their features can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.

--- a/doc/devices/braket_remote.rst
+++ b/doc/devices/braket_remote.rst
@@ -101,7 +101,7 @@ from :mod:`braket.pennylane_plugin.ops <.ops>`:
 
 
 Gradient computation on Braket with a QAOA Hamiltonian
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Currently, PennyLane will compute grouping indices for QAOA Hamiltonians and use them to split the Hamiltonian into multiple expectation values. If you wish to use `SV1’s adjoint differentiation capability<https://docs.aws.amazon.com/braket/latest/developerguide/hybrid.html>` when running QAOA from PennyLane, you will need reconstruct the cost Hamiltonian to remove the grouping indices from the cost Hamiltonian, like so:
 
 .. code-block:: python

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,17 +20,28 @@ away in PennyLane, without the need to import any additional packages.
 Devices
 ~~~~~~~
 
-This plugin provides two Braket devices for use with PennyLane:
+This plugin provides four Braket devices for use with PennyLane - two supporting gate-based devices,
+and two supporting Analogue Hamiltonian Simulation (AHS) on a Rydberg atom system:
 
 .. title-card::
     :name: 'braket.aws.qubit'
-    :description: Runs circuits on the remote Amazon Braket service.
+    :description: Runs gate-based circuits on the remote Amazon Braket service.
     :link: devices/braket_remote.html
 
 .. title-card::
     :name: 'braket.local.qubit'
-    :description: Runs circuits on the Braket SDK's local simulator.
+    :description: Runs gate-based circuits on the Braket SDK's local simulator.
     :link: devices/braket_local.html
+
+.. title-card::
+    :name: 'braket.aws.ahs'
+    :description: Runs AHS on the remote Amazon Braket service.
+    :link: devices/ahs_remote.html
+
+.. title-card::
+    :name: 'braket.local.ahs'
+    :description: Runs AHS on the Braket SDK's local Rygberg atom simulator.
+    :link: devices/ahs_local.html
 
 .. raw:: html
 
@@ -69,6 +80,8 @@ and the `Amazon Braket <https://github.com/aws/amazon-braket-examples>`_ example
 
    devices/braket_remote
    devices/braket_local
+   devices/ahs_local
+   devices/ahs_remote
 
 .. toctree::
    :maxdepth: 1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,7 +20,7 @@ away in PennyLane, without the need to import any additional packages.
 Devices
 ~~~~~~~
 
-This plugin provides four Braket devices for use with PennyLane - two supporting gate-based devices,
+This plugin provides four Braket devices for use with PennyLane - two supporting gate-based computations,
 and two supporting Analogue Hamiltonian Simulation (AHS) on a Rydberg atom system:
 
 .. title-card::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ Devices
 ~~~~~~~
 
 This plugin provides four Braket devices for use with PennyLane - two supporting gate-based computations,
-and two supporting Analogue Hamiltonian Simulation (AHS) on a Rydberg atom system:
+and two supporting analog Hamiltonian simulation (AHS):
 
 .. title-card::
     :name: 'braket.aws.qubit'
@@ -40,7 +40,7 @@ and two supporting Analogue Hamiltonian Simulation (AHS) on a Rydberg atom syste
 
 .. title-card::
     :name: 'braket.local.ahs'
-    :description: Runs AHS on the Braket SDK's local Rygberg atom simulator.
+    :description: Runs AHS on the Braket SDK's local simulator.
     :link: devices/ahs_local.html
 
 .. raw:: html

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     package_dir={"": "src"},
     install_requires=[
         "amazon-braket-sdk>=1.35.0",
-        "pennylane==0.29.1",
+        # "pennylane=0.30.0"
+        "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     ],
     entry_points={
         "pennylane.plugins": [
@@ -39,6 +40,8 @@ setup(
             # `pennylane.device` device loader.
             "braket.aws.qubit = braket.pennylane_plugin:BraketAwsQubitDevice",
             "braket.local.qubit = braket.pennylane_plugin:BraketLocalQubitDevice",
+            "braket.aws.ahs = braket.pennylane_plugin:BraketAwsAhsDevice",
+            "braket.local.ahs = braket.pennylane_plugin:BraketLocalAhsDevice",
         ]
     },
     extras_require={

--- a/src/braket/pennylane_plugin/__init__.py
+++ b/src/braket/pennylane_plugin/__init__.py
@@ -19,10 +19,6 @@ from braket.pennylane_plugin.braket_device import (  # noqa: F401
     BraketAwsQubitDevice,
     BraketLocalQubitDevice,
 )
-from braket.pennylane_plugin.ahs_device import (
-    BraketAwsAhsDevice,
-    BraketLocalAhsDevice,
-)
 from braket.pennylane_plugin.ops import (  # noqa: F401
     MS,
     PSWAP,

--- a/src/braket/pennylane_plugin/__init__.py
+++ b/src/braket/pennylane_plugin/__init__.py
@@ -11,6 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from braket.pennylane_plugin.ahs_device import (  # noqa: F401
+    BraketAwsAhsDevice,
+    BraketLocalAhsDevice,
+)
 from braket.pennylane_plugin.braket_device import (  # noqa: F401
     BraketAwsQubitDevice,
     BraketLocalQubitDevice,

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -1,0 +1,413 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""
+Devices
+=======
+
+**Module name:** :mod:`braket.pennylane_braket.ahs_device`
+
+.. currentmodule:: braket.pennylane_braket.ahs_device
+
+Braket Analogue Hamiltonian Simulation (AHS) devices to be used with PennyLane
+
+Classes
+-------
+
+.. autosummary::
+   BraketAwsAhsDevice
+   BraketLocalAhsDevice
+
+Code details
+~~~~~~~~~~~~
+"""
+from enum import Enum, auto
+from typing import Iterable, List, Optional, Union
+
+import numpy as np
+from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
+from braket.aws import AwsDevice, AwsQuantumTask, AwsSession
+from braket.devices import Device, LocalSimulator
+from pennylane import QubitDevice
+from pennylane._version import __version__
+from pennylane.pulse import ParametrizedEvolution
+from pennylane.pulse.hardware_hamiltonian import HardwareHamiltonian, HardwarePulse
+
+from .ahs_translation import (
+    _create_register,
+    _evaluate_pulses,
+    _get_sample_times,
+    translate_ahs_shot_result,
+    translate_pulse_to_driving_field,
+)
+
+
+class Shots(Enum):
+    """Used to specify the default number of shots in BraketAwsQubitDevice"""
+
+    DEFAULT = auto()
+
+
+class BraketAhsDevice(QubitDevice):
+    """Abstract Amazon Braket device for analogue hamiltonian simulation with PennyLane.
+
+    Args:
+        wires (int or Iterable[int, str]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers
+            (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
+        device (Device): The Amazon Braket device to use with PennyLane.
+        shots (int or Shots.DEFAULT): Number of executions to run to aquire measurements.
+            Default: Shots.DEFAULT
+    """
+
+    name = "Braket AHS PennyLane plugin"
+    pennylane_requires = ">=0.30.0"
+    version = __version__
+    author = "Xanadu Inc."
+    short_name = "braket_ahs_device"
+
+    operations = {"ParametrizedEvolution"}
+
+    def __init__(
+        self,
+        wires: Union[int, Iterable],
+        device: Device,
+        *,
+        shots: Union[int, Shots] = Shots.DEFAULT,
+    ):
+        if not shots:
+            raise RuntimeError(f"This device requires shots. Received shots={shots}")
+        # Simulator default of 0 not suitable for AHS simulator, use DEFAULT_SHOTS_QPU for both
+        elif shots == Shots.DEFAULT:
+            num_shots = AwsDevice.DEFAULT_SHOTS_QPU
+        else:
+            num_shots = shots
+
+        super().__init__(wires=wires, shots=num_shots)
+
+        self._device = device
+        self._register = None
+        self._pulses = None
+        self._ahs_program = None
+        self._task = None
+
+    def apply(self, operations: List[ParametrizedEvolution], **kwargs):
+        """Convert the pulse operation to an AHS program and run on the connected device
+
+        Args:
+            operations(List[ParametrizedEvolution]): a list containing a single
+                ParametrizedEvolution operator
+        """
+
+        if not np.all([op.name in self.operations for op in operations]):
+            raise NotImplementedError(
+                "Device {self.short_name} expected only operations "
+                "{self.operations} but recieved {operations}"
+            )
+        self._validate_operations(operations)
+        ev_op = operations[0]  # only one!
+
+        self._validate_pulses(ev_op.H.pulses)
+        ahs_program = self.create_ahs_program(ev_op)
+        self._task = self._run_task(ahs_program)
+
+    @property
+    def task(self):
+        return self._task
+
+    @property
+    def ahs_program(self):
+        return self._ahs_program
+
+    @property
+    def register(self):
+        return self._register
+
+    @property
+    def samples(self):
+        if self._task:
+            return self._task.result()
+        return None
+
+    def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
+        """Run and return a task executing the AnalogueHamiltonianSimulation program on
+        the device"""
+        raise NotImplementedError("Running a task not implemented for the base class")
+
+    def _ahs_program_from_evolution(self, evolution: ParametrizedEvolution):
+        """Create AHS program for upload to hardware from a ParametrizedEvolution
+
+        Args:
+            evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
+                to be converted into an Analogue Hamiltonian Simulation program
+
+        Returns:
+            AnalogHamiltonianSimulation: a program containing the register and drive
+                information for running an AHS task on simulation or hardware"""
+
+        # sets self._pulses to be the evaluated pulses (now only a function of time)
+        self._pulses = _evaluate_pulses(evolution)
+        self._register = _create_register(evolution.H.settings.register)
+
+        time_interval = evolution.t
+        time_points = _get_sample_times(time_interval)
+
+        # no gurarentee that global drive is index 0 once we start allowing more just global drive
+        drive = translate_pulse_to_driving_field(self._pulses[0], time_points)
+
+        return AnalogHamiltonianSimulation(register=self._register, hamiltonian=drive)
+
+    def create_ahs_program(self, evolution: ParametrizedEvolution):
+        """Create AHS program for upload to hardware from a ParametrizedEvolution
+
+        Args:
+            evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
+                to be converted into an Analogue Hamiltonian Simulation program
+
+        Returns:
+            AnalogHamiltonianSimulation: a program containing the register and drive
+                information for running an AHS task on simulation or hardware"""
+
+        ahs_program = self._ahs_program_from_evolution(evolution)
+
+        self._ahs_program = ahs_program
+
+        return ahs_program
+
+    def generate_samples(self):
+        r"""Returns the computational basis samples measured for all wires.
+
+        Returns:
+             array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
+        """
+        return [translate_ahs_shot_result(res) for res in self.samples.measurements]
+
+    def _validate_operations(self, operations: List[ParametrizedEvolution]):
+        """Confirms that the list of operations provided contains a single ParametrizedEvolution
+        from a HardwareHamiltonian with only a single, global pulse
+
+        Args:
+            operations(List[ParametrizedEvolution]): a list containing a single
+                ParametrizedEvolution operator
+        """
+
+        if len(operations) > 1:
+            raise NotImplementedError(
+                f"Support for multiple ParametrizedEvolution operators in a single circuit is "
+                f"not yet implemented. Received {len(operations)} operators."
+            )
+
+        ev_op = operations[0]  # only one!
+
+        if not isinstance(ev_op.H, HardwareHamiltonian):
+            raise RuntimeError(
+                f"Expected a HardwareHamiltonian instance for interfacing with the device, but "
+                f"recieved {type(ev_op.H)}."
+            )
+
+        if not set(ev_op.wires) == set(self.wires):
+            raise RuntimeError(
+                f"Device contains wires {self.wires}, but received a `ParametrizedEvolution` "
+                f"operator working on wires {ev_op.wires}. Device wires must match wires of "
+                f"the evolution."
+            )
+
+        if len(ev_op.H.settings.register) != len(self.wires):
+            raise RuntimeError(
+                f"The defined interaction term has register {ev_op.H.settings.register} of length "
+                f"{len(ev_op.H.settings.register)}, which does not match the number of wires on "
+                f"the device ({len(self.wires)})"
+            )
+
+    def _validate_pulses(self, pulses: List[HardwarePulse]):
+        """Confirms that the list of HardwarePulses describes a single, global pulse
+
+        Args:
+            pulses: List of HardwarePulses
+
+        Raises:
+            RuntimeError, NotImplementedError"""
+
+        if not pulses:
+            raise RuntimeError("No pulses found in the ParametrizedEvolution")
+
+        if len(pulses) > 1:
+            raise NotImplementedError(
+                f"Multiple pulses in a Hamiltonian are not currently supported. "
+                f"Received {len(pulses)} pulses."
+            )
+
+        if pulses[0].wires != self.wires:
+            raise NotImplementedError(
+                f"Only global drive is currently supported. Found drive defined for subset "
+                f"{[pulses[0].wires]} of all wires [{self.wires}]"
+            )
+
+
+class BraketAwsAhsDevice(BraketAhsDevice):
+    """Amazon Braket AHS device for hardware in PennyLane.
+
+    Args:
+        wires (int or Iterable[int, str]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers
+            (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
+        device_arn (str): The ARN identifying the ``AwsDevice`` to be used to
+            run circuits; The corresponding AwsDevice must support Analogue Hamiltonian Simulation.
+            You can get device ARNs from the Amazon Braket console or from the Amazon Braket
+            Developer Guide.
+        s3_destination_folder (AwsSession.S3DestinationFolder): Name of the S3 bucket
+            and folder, specified as a tuple.
+        poll_timeout_seconds (float): Total time in seconds to wait for
+            results before timing out.
+        poll_interval_seconds (float): The polling interval for results in seconds.
+        shots (int or Shots.DEFAULT): Number of executions to run to aquire measurements.
+            Default: Shots.DEFAULT
+        aws_session (Optional[AwsSession]): An AwsSession object created to manage
+            interactions with AWS services, to be supplied if extra control
+            is desired. Default: None
+    """
+
+    name = "Braket Device for AHS in PennyLane"
+    short_name = "braket.aws.ahs"
+
+    def __init__(
+        self,
+        wires: Union[int, Iterable],
+        device_arn: str,
+        s3_destination_folder: AwsSession.S3DestinationFolder = None,
+        *,
+        poll_timeout_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_TIMEOUT,
+        poll_interval_seconds: float = AwsQuantumTask.DEFAULT_RESULTS_POLL_INTERVAL,
+        shots: Union[int, Shots] = Shots.DEFAULT,
+        aws_session: Optional[AwsSession] = None,
+    ):
+        device = AwsDevice(device_arn, aws_session=aws_session)
+        user_agent = f"BraketPennylanePlugin/{__version__}"
+        device.aws_session.add_braket_user_agent(user_agent)
+
+        super().__init__(wires=wires, device=device, shots=shots)
+
+        self._s3_folder = s3_destination_folder
+        self._poll_timeout_seconds = poll_timeout_seconds
+        self._poll_interval_seconds = poll_interval_seconds
+
+    @property
+    def hardware_capabilities(self):
+        """Dictionary of hardware capabilities for the hardware device"""
+        return dict(self._device.properties.paradigm)
+
+    @property
+    def settings(self):
+        """Dictionary of constants set by the hardware.
+
+        Used to enable initializing hardware-consistent Hamiltonians by saving
+        all the values that would need to be passed, i.e.:
+
+            >>> dev_remote = qml.device('braket.aws.ahs', wires=3)
+            >>> dev_pl = qml.device('default.qubit', wires=3)
+            >>> settings = dev_remote.settings
+            >>> H_int = qml.pulse.rydberg.rydberg_interaction(coordinates, **settings)
+
+        By passing the ``settings`` from the remote device to ``rydberg_interaction``, an
+        ``H_int`` Hamiltonian term is created using the constants specific to the hardware.
+        This is relevant for simulating the hardware in PennyLane on the ``default.qubit`` device.
+        """
+        return {"interaction_coeff": self._get_rydberg_c6()}
+
+    def _get_rydberg_c6(self):
+        """Get rydberg C6 and convert from rad/s m^6 (AWS units) to Mrad/s um^6
+        (PL simulation units)"""
+        c6 = float(self._device.properties.paradigm.rydberg.c6Coefficient)  # rad/s x m^6
+        c6 = 1e-6 * c6  # rad/s --> M rad/s
+        c6 = c6 * 1e36  # m^6 --> um^6
+        return c6
+
+    def create_ahs_program(self, evolution: ParametrizedEvolution):
+        """Create AHS program for upload to hardware from a ParametrizedEvolution
+
+        Args:
+            evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
+                to be converted into an Analogue Hamiltonian Simulation program
+
+        Returns:
+            AnalogHamiltonianSimulation: a program containing the register and drive
+                information for running an AHS task on simulation or hardware"""
+
+        ahs_program = self._ahs_program_from_evolution(evolution)
+        ahs_program_discretized = ahs_program.discretize(self._device)
+
+        self._ahs_program = ahs_program_discretized
+
+        return ahs_program_discretized
+
+    def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
+        """Run and return a task executing the AnalogueHamiltonianSimulation program on
+        the device"""
+        task = self._device.run(
+            ahs_program,
+            s3_destination_folder=self._s3_folder,
+            shots=self.shots,
+            poll_timeout_seconds=self._poll_timeout_seconds,
+            poll_interval_seconds=self._poll_interval_seconds,
+        )
+        return task
+
+
+class BraketLocalAhsDevice(BraketAhsDevice):
+    """Amazon Braket LocalSimulator AHS device for PennyLane.
+
+    Args:
+        wires (int or Iterable[int, str]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers
+            (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
+        shots (int or Shots.DEFAULT): Number of executions to run to aquire measurements.
+            Default: Shots.DEFAULT
+    """
+
+    name = "Braket LocalSimulator for AHS in PennyLane"
+    short_name = "braket.local.ahs"
+
+    def __init__(
+        self,
+        wires: Union[int, Iterable],
+        *,
+        shots: Union[int, Shots] = Shots.DEFAULT,
+    ):
+        device = LocalSimulator("braket_ahs")
+        super().__init__(wires=wires, device=device, shots=shots)
+
+    @property
+    def settings(self):
+        """Dictionary of constants set by the hardware.
+
+        Used to enable initializing hardware-consistent Hamiltonians by saving
+        all the values that would need to be passed, i.e.:
+
+            >>> dev_remote = qml.device('braket.aws.ahs', wires=3)
+            >>> dev_pl = qml.device('default.qubit', wires=3)
+            >>> settings = dev_remote.settings
+            >>> H_int = qml.pulse.rydberg.rydberg_interaction(coordinates, **settings)
+
+        By passing the ``settings`` from the remote device to ``rydberg_interaction``, an
+        ``H_int`` Hamiltonian term is created using the constants specific to the hardware.
+        This is relevant for simulating the remote device in PennyLane on the ``default.qubit``
+        device.
+        """
+        # C6 for the Rubidium transition used by the simulator, converted to Mrad/s x um^6
+        return {"interaction_coeff": 5420000}
+
+    def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
+        """Run and return a task executing the AnalogueHamiltonianSimulation program on the
+        device"""
+        task = self._device.run(ahs_program, shots=self.shots, steps=100)
+        return task

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -281,8 +281,10 @@ class BraketAwsAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from $2 \pi$ MHz to rad/s), while time will be divided by 1e6 (converted from
-        microseconds to seconds).
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+        to meters).
+
 
         See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
         and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
@@ -392,8 +394,9 @@ class BraketLocalAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for simulated hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from $2 \pi$ MHz to rad/s), while time will be divided by 1e6 (converted from
-        microseconds to seconds).
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
+        to meters).
 
         See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
         and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -19,7 +19,7 @@ Devices
 
 .. currentmodule:: braket.pennylane_braket.ahs_device
 
-Braket Analogue Hamiltonian Simulation (AHS) devices to be used with PennyLane
+Braket Analog Hamiltonian Simulation (AHS) devices to be used with PennyLane
 
 Classes
 -------
@@ -59,7 +59,7 @@ class Shots(Enum):
 
 
 class BraketAhsDevice(QubitDevice):
-    """Abstract Amazon Braket device for analogue hamiltonian simulation with PennyLane.
+    """Abstract Amazon Braket device for analog Hamiltonian simulation with PennyLane.
 
     Args:
         wires (int or Iterable[int, str]): Number of subsystems represented by the device,
@@ -140,7 +140,7 @@ class BraketAhsDevice(QubitDevice):
         return None
 
     def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
-        """Run and return a task executing the AnalogueHamiltonianSimulation program on
+        """Run and return a task executing the AnalogHamiltonianSimulation program on
         the device"""
         raise NotImplementedError("Running a task not implemented for the base class")
 
@@ -149,7 +149,7 @@ class BraketAhsDevice(QubitDevice):
 
         Args:
             evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
-                to be converted into an Analogue Hamiltonian Simulation program
+                to be converted into an AnalogHamiltonianSimulation program
 
         Returns:
             AnalogHamiltonianSimulation: a program containing the register and drive
@@ -172,7 +172,7 @@ class BraketAhsDevice(QubitDevice):
 
         Args:
             evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
-                to be converted into an Analogue Hamiltonian Simulation program
+                to be converted into an AnalogHamiltonianSimulation program
 
         Returns:
             AnalogHamiltonianSimulation: a program containing the register and drive
@@ -264,7 +264,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
         device_arn (str): The ARN identifying the ``AwsDevice`` to be used to
-            run circuits; The corresponding AwsDevice must support Analogue Hamiltonian Simulation.
+            run circuits; The corresponding AwsDevice must support analog Hamiltonian simulation.
             You can get device ARNs from the Amazon Braket console or from the Amazon Braket
             Developer Guide.
         s3_destination_folder (AwsSession.S3DestinationFolder): Name of the S3 bucket
@@ -355,7 +355,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
 
         Args:
             evolution (ParametrizedEvolution): the PennyLane operator describing the pulse
-                to be converted into an Analogue Hamiltonian Simulation program
+                to be converted into an AnalogHamiltonianSimulation program
 
         Returns:
             AnalogHamiltonianSimulation: a program containing the register and drive
@@ -369,7 +369,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
         return ahs_program_discretized
 
     def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
-        """Run and return a task executing the AnalogueHamiltonianSimulation program on
+        """Run and return a task executing the AnalogHamiltonianSimulation program on
         the device"""
         task = self._device.run(
             ahs_program,
@@ -443,7 +443,7 @@ class BraketLocalAhsDevice(BraketAhsDevice):
         return {"interaction_coeff": 862620}
 
     def _run_task(self, ahs_program: AnalogHamiltonianSimulation):
-        """Run and return a task executing the AnalogueHamiltonianSimulation program on the
+        """Run and return a task executing the AnalogHamiltonianSimulation program on the
         device"""
         task = self._device.run(ahs_program, shots=self.shots, steps=100)
         return task

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -472,6 +472,8 @@ class BraketAwsAhsDevice(BraketAhsDevice):
 class BraketLocalAhsDevice(BraketAhsDevice):
     """Amazon Braket LocalSimulator AHS device for PennyLane.
 
+    Emulates :class:`~.BraketAwsAhsDevice` by running <link to https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>
+
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -281,7 +281,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
         microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
         to meters).
 
@@ -394,7 +394,7 @@ class BraketLocalAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for simulated hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
+        to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
         microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
         to meters).
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -366,7 +366,7 @@ class BraketAhsDevice(QubitDevice):
 class BraketAwsAhsDevice(BraketAhsDevice):
     """Amazon Braket AHS device for hardware in PennyLane.
 
-More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.
+    More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.
 
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
@@ -474,7 +474,7 @@ More information about AHS and the capabilities of the hardware can be found in 
 class BraketLocalAhsDevice(BraketAhsDevice):
     """Amazon Braket LocalSimulator AHS device for PennyLane.
 
-    Emulates :class:`~.BraketAwsAhsDevice` by running <link to https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>
+    Emulates :class:`~.BraketAwsAhsDevice` by running `Braket's local AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_.
 
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -287,7 +287,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
 
         When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
         are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
-        functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
+        functions should follow the conventions specified in the PennyLane docs to ensure correct unit conversion.
         See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
         and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
         Pennylane for specification of expected input units, and examples for creating hardware-compatible
@@ -402,7 +402,7 @@ class BraketLocalAhsDevice(BraketAhsDevice):
 
         When reading hardware specifications from the Braket backend, bear in mind that all units are SI and frequencies
         are in rad/s. This conversion is done when creating a pulse program for upload, and units in the PennyLane
-        functions should follow the conventions specified in the docstrings to ensure correct unit conversion.
+        functions should follow the conventions specified in the PennyLane docs to ensure correct unit conversion.
         See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
         and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
         Pennylane for specification of expected input units, and examples for creating hardware-compatible

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -114,7 +114,6 @@ class BraketAhsDevice(QubitDevice):
                 "Device {self.short_name} expected only operations "
                 "{self.operations} but recieved {operations}"
             )
-
         self._validate_operations(operations)
         ev_op = operations[0]  # only one!
 
@@ -261,7 +260,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
     More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.
 
     Args:
-        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+        wires (int or Iterable[int, str]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
         device_arn (str): The ARN identifying the ``AwsDevice`` to be used to

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -281,7 +281,7 @@ class BraketAwsAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
         microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
         to meters).
 
@@ -394,7 +394,7 @@ class BraketLocalAhsDevice(BraketAhsDevice):
     .. note::
         It is important to keep track of units when specifying electromagnetic pulses for simulated hardware control.
         The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
-        to hardware (converted from :math:`2 \pi`MHz to rad/s), while time will be divided by 1e6 (converted from
+        to hardware (converted from :math:`2 \pi` MHz to rad/s), while time will be divided by 1e6 (converted from
         microseconds to seconds). Specification of atom coordinates will be divided by 1e6 (converted from micrometers
         to meters).
 

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -366,6 +366,8 @@ class BraketAhsDevice(QubitDevice):
 class BraketAwsAhsDevice(BraketAhsDevice):
     """Amazon Braket AHS device for hardware in PennyLane.
 
+More information about AHS and the capabilities of the hardware can be found in the `Amazon Braket Developer Guide <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html>`_.
+
     Args:
         wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
             or iterable that contains unique labels for the subsystems as numbers

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -384,7 +384,8 @@ class BraketAwsAhsDevice(BraketAhsDevice):
 class BraketLocalAhsDevice(BraketAhsDevice):
     """Amazon Braket LocalSimulator AHS device for PennyLane.
 
-    Emulates :class:`~.BraketAwsAhsDevice` by running `Braket's local AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_.
+    Runs programs on `Braket's local AHS simulator <https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-ahs-local>`_.
+    Can be used to emulate the :class:`~.BraketAwsAhsDevice`.
 
     Args:
         wires (int or Iterable[int, str]): Number of subsystems represented by the device,

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -19,7 +19,7 @@ Devices
 
 .. currentmodule:: braket.pennylane_braket.ahs_device
 
-Braket Analog Hamiltonian Simulation (AHS) devices to be used with PennyLane
+Braket analog Hamiltonian simulation (AHS) devices to be used with PennyLane
 
 Classes
 -------

--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -277,6 +277,18 @@ class BraketAwsAhsDevice(BraketAhsDevice):
         aws_session (Optional[AwsSession]): An AwsSession object created to manage
             interactions with AWS services, to be supplied if extra control
             is desired. Default: None
+
+    .. note::
+        It is important to keep track of units when specifying electromagnetic pulses for hardware control.
+        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+        to hardware (converted from $2 \pi$ MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds).
+
+        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+        Pennylane for specification of expected input units, and examples for creating hardware-compatible
+        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+        operators in PennyLane.
     """
 
     name = "Braket Device for AHS in PennyLane"
@@ -376,6 +388,18 @@ class BraketLocalAhsDevice(BraketAhsDevice):
             (i.e., ``[-1, 0, 2]``) or strings (``['ancilla', 'q1', 'q2']``).
         shots (int or Shots.DEFAULT): Number of executions to run to aquire measurements.
             Default: Shots.DEFAULT
+
+    .. note::
+        It is important to keep track of units when specifying electromagnetic pulses for simulated hardware control.
+        The frequency and amplitude provided in PennyLane will be multiplied to a factor of 1e6 when translating
+        to hardware (converted from $2 \pi$ MHz to rad/s), while time will be divided by 1e6 (converted from
+        microseconds to seconds).
+
+        See `rydberg_interaction <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_interaction.html>`_
+        and `rydberg_drive <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.rydberg_drive.html>`_ in
+        Pennylane for specification of expected input units, and examples for creating hardware-compatible
+        `ParametrizedEvolution <https://docs.pennylane.ai/en/stable/code/api/pennylane.pulse.ParametrizedEvolution.html>`_
+        operators in PennyLane.
     """
 
     name = "Braket LocalSimulator for AHS in PennyLane"

--- a/src/braket/pennylane_plugin/ahs_translation.py
+++ b/src/braket/pennylane_plugin/ahs_translation.py
@@ -72,9 +72,9 @@ def translate_pulse_to_driving_field(pulse: HardwarePulse, time_points: ArrayLik
             AnalogueHamiltonianSimulation object
     """
 
-    # scaling factor for amp and frequency detuning converts from Mrad/s to rad/s
-    amplitude = _convert_to_time_series(pulse.amplitude, time_points, scaling_factor=1e6)
-    detuning = _convert_to_time_series(pulse.frequency, time_points, scaling_factor=1e6)
+    # scaling factor for amp and frequency detuning converts from MHz to rad/s
+    amplitude = _convert_to_time_series(pulse.amplitude, time_points, scaling_factor=2 * np.pi * 1e6)
+    detuning = _convert_to_time_series(pulse.frequency, time_points, scaling_factor=2 * np.pi * 1e6)
     phase = _convert_to_time_series(pulse.phase, time_points)
 
     drive = DrivingField(amplitude=amplitude, detuning=detuning, phase=phase)
@@ -188,7 +188,7 @@ def _get_sample_times(time_interval: ArrayLike):
     end = interval_ns[1]
 
     # number of points must ensure at least 50ns between sample points
-    num_points = int((end - start) // 50)
+    num_points = int((end - start) // 50) + 1
 
     # we want an integer number of nanoseconds
     times = np.linspace(start, end, num_points, dtype=int)

--- a/src/braket/pennylane_plugin/ahs_translation.py
+++ b/src/braket/pennylane_plugin/ahs_translation.py
@@ -1,0 +1,197 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from functools import partial
+from typing import Callable, List, Tuple, Union
+
+import numpy as np
+from braket.ahs.atom_arrangement import AtomArrangement
+from braket.ahs.driving_field import DrivingField
+from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import ShotResult
+from braket.timings.time_series import TimeSeries
+from numpy.typing import ArrayLike
+from pennylane.pulse import ParametrizedEvolution
+from pennylane.pulse.hardware_hamiltonian import HardwarePulse
+
+
+def _convert_to_time_series(
+    pulse_parameter: Union[float, Callable],
+    time_points: ArrayLike,
+    scaling_factor: float = 1,
+):
+    """Converts pulse information into a TimeSeries
+
+    Args:
+        pulse_parameter(Union[float, Callable]): a physical parameter (pulse, amplitude
+            or frequency detuning) of the pulse. If this is a callalbe, it has already been
+            partially evaluated, such that it is only a function of time.
+        time_points(array): the times where parameters will be set in the TimeSeries, specified
+            in seconds
+        scaling_factor(float): A multiplication factor for the pulse_parameter
+            where relevant to convert between units. Defaults to 1.
+
+    Returns:
+        TimeSeries: a description of setpoints and corresponding times
+    """
+
+    ts = TimeSeries()
+
+    if callable(pulse_parameter):
+        # convert time to microseconds to evaluate (expected unit for the PL functions)
+        vals = [float(pulse_parameter(t * 1e6)) * scaling_factor for t in time_points]
+    else:
+        vals = [pulse_parameter * scaling_factor for t in time_points]
+
+    for t, v in zip(time_points, vals):
+        ts.put(t, v)
+
+    return ts
+
+
+def translate_pulse_to_driving_field(pulse: HardwarePulse, time_points: ArrayLike):
+    """Converts a ``HardwarePulse`` from PennyLane describing a global drive to a
+    ``DrivingField`` from Braket AHS
+
+    Args:
+        pulse[HardwarePulse]: a dataclass object containing amplitude, phase and frequency
+            detuning information
+        time_interval(array[float, float]): The start and end time for the applied pulse
+
+    Returns:
+        drive(DrivingField): the object representing the global drive for the
+            AnalogueHamiltonianSimulation object
+    """
+
+    # scaling factor for amp and frequency detuning converts from Mrad/s to rad/s
+    amplitude = _convert_to_time_series(pulse.amplitude, time_points, scaling_factor=1e6)
+    detuning = _convert_to_time_series(pulse.frequency, time_points, scaling_factor=1e6)
+    phase = _convert_to_time_series(pulse.phase, time_points)
+
+    drive = DrivingField(amplitude=amplitude, detuning=detuning, phase=phase)
+
+    return drive
+
+
+def _evaluate_pulses(ev_op: ParametrizedEvolution):
+    """Feeds in the parameters in order to partially evaluate the callables (amplitude,
+    phase and/or frequency detuning) describing the pulses, so they are only a function of time.
+    Saves the pulses on the device as `dev.pulses`.
+
+    Args:
+        ev_op(ParametrizedEvolution): the operator containing the pulses to be evaluated
+    """
+
+    params = ev_op.parameters
+    pulses = ev_op.H.pulses
+
+    evaluated_pulses = []
+    idx = 0
+
+    for pulse in pulses:
+        amplitude = pulse.amplitude
+        if callable(pulse.amplitude):
+            amplitude = partial(pulse.amplitude, params[idx])
+            idx += 1
+
+        phase = pulse.phase
+        if callable(pulse.phase):
+            phase = partial(pulse.phase, params[idx])
+            idx += 1
+
+        detuning = pulse.frequency
+        if callable(pulse.frequency):
+            detuning = partial(pulse.frequency, params[idx])
+            idx += 1
+
+        evaluated_pulses.append(
+            HardwarePulse(amplitude=amplitude, phase=phase, frequency=detuning, wires=pulse.wires)
+        )
+
+    return evaluated_pulses
+
+
+def _create_register(coordinates: List[Tuple[float, float]]):
+    """Create an AtomArrangement to describe the atom layout from the coordinates in the
+    ParametrizedEvolution, and saves it as self._register
+
+    Args:
+        coordinates(List): a list of pairs [x, y] of coordinates denoting atom locations, in um
+    """
+
+    register = AtomArrangement()
+    for [x, y] in coordinates:
+        # PL asks users to specify in um, Braket expects SI units
+        register.add([x * 1e-6, y * 1e-6])
+
+    return register
+
+
+def translate_ahs_shot_result(res: ShotResult):
+    """This function converts a single shot of the QuEra measurement results to
+    0 (ground), 1 (excited) and NaN (failed to measure) for all atoms in the result.
+
+    Args:
+        res(ShotResult): the result of a single measurement shot
+
+    The results are summarized via 3 values: status, pre_sequence, and post_sequence.
+
+    Status is success or fail. The pre_sequence is 1 if an atom in the ground state was
+    successfully initialized, and 0 otherwise. The post_sequence is 1 if an atom in the
+    ground state was measured, and 0 otherwise. Comparison of pre_sequence and post_sequence
+    reveals one of 4 possible outcomes. The first two (initial measurement of 0) indicate a
+    failure to initialize correctly, and will yeild a NaN result. The second two are
+    measurements of the excited and ground state repsectively, and yield 1 and 0.
+
+    0 --> 0: NaN - Atom failed to be placed (no atom in the ground state either before or after)
+    0 --> 1: NaN - Atom failed to be placed (but was recaptured, or something else odd happened)
+    1 --> 0: 1 (Rydberg state) - atom measured in ground state before, but not after
+    1 --> 1: 0 (ground state) - atom measured in ground state both before and after
+    """
+
+    # if entire measurement failed, all NaN
+    if not res.status.value.lower() == "success":
+        return np.array([np.NaN for i in res.pre_sequence])
+
+    # if a single atom failed to initialize, NaN for that individual measurement
+    pre_sequence = [i if i else np.NaN for i in res.pre_sequence]
+
+    # set entry to 0 if ground state measured
+    # 1 if excited state measured
+    # and NaN if measurement failed
+    return np.array(pre_sequence - res.post_sequence)
+
+
+def _get_sample_times(time_interval: ArrayLike):
+    """Takes a time interval and returns an array of times with a minimum of 50ns spacing
+
+    Args:
+        time_interval(array[float, float]): an array with start and end times for the
+            pulse, in us
+
+    Returns:
+        times(array[float]): an array of times sampled at 1ns intervals between the start
+            and end times, in SI units (seconds)
+    """
+    # time_interval from PL is in microseconds, we convert to ns
+    interval_ns = np.array(time_interval) * 1e3
+    start = interval_ns[0]
+    end = interval_ns[1]
+
+    # number of points must ensure at least 50ns between sample points
+    num_points = int((end - start) // 50)
+
+    # we want an integer number of nanoseconds
+    times = np.linspace(start, end, num_points, dtype=int)
+
+    # we return time in seconds
+    return times / 1e9

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -37,6 +37,7 @@ def f2(p, t):
 def amp(p, t):
     return p[0] * np.exp(-((t - p[1]) ** 2) / (2 * p[2] ** 2))
 
+
 params1 = 1.2
 params2 = [3.4, 5.6]
 params_amp = [2.5, 0.9, 0.3]
@@ -130,6 +131,7 @@ class TestDeviceAttributes:
         res = circuit()
 
         assert len(res) == shots
+
 
 class TestQnodeIntegration:
     """Test integration with the qnode"""

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests that gates are correctly applied in the plugin device"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
+from pennylane.pulse.rydberg import rydberg_drive, rydberg_interaction
+
+from braket.pennylane_plugin.ahs_device import BraketAwsAhsDevice, BraketLocalAhsDevice
+
+# =========================================================
+coordinates = [[0, 0], [0, 5], [5, 0]]  # in micrometers
+
+
+def f1(p, t):
+    return p * np.sin(t) * (t - 1)
+
+
+def f2(p, t):
+    return p[0] * np.cos(p[1] * t**2)
+
+
+def amp(p, t):
+    return p[0] * np.exp(-((t - p[1]) ** 2) / (2 * p[2] ** 2))
+
+
+params1 = 1.2
+params2 = [3.4, 5.6]
+params_amp = [2.5, 0.9, 0.3]
+
+# Hamiltonians to be tested
+H_i = rydberg_interaction(coordinates)
+
+HAMILTONIANS_AND_PARAMS = [
+    (H_i + rydberg_drive(1, 2, 3, wires=[0, 1, 2]), []),
+    (H_i + rydberg_drive(amp, 1, 2, wires=[0, 1, 2]), [params_amp]),
+    (H_i + rydberg_drive(2, f1, 2, wires=[0, 1, 2]), [params1]),
+    (H_i + rydberg_drive(2, 2, f2, wires=[0, 1, 2]), [params2]),
+    (H_i + rydberg_drive(amp, 1, f2, wires=[0, 1, 2]), [params_amp, params2]),
+    (H_i + rydberg_drive(4, f2, f1, wires=[0, 1, 2]), [params2, params1]),
+    (H_i + rydberg_drive(amp, f2, 4, wires=[0, 1, 2]), [params_amp, params2]),
+    (H_i + rydberg_drive(amp, f2, f1, wires=[0, 1, 2]), [params_amp, params2, params1]),
+]
+
+HARDWARE_ARN_NRS = ["arn:aws:braket:us-east-1::device/qpu/quera/Aquila"]
+
+ALL_DEVICES = [
+    ("braket.local.ahs", None, "RydbergAtomSimulator"),
+    ("braket.aws.ahs", "arn:aws:braket:us-east-1::device/qpu/quera/Aquila", "Aquila"),
+]
+
+
+DEVS = [("arn:aws:braket:us-east-1::device/qpu/quera/Aquila", "Aquila")]
+
+
+@pytest.mark.parametrize("arn_nr, name", DEVS)
+def test_initialization(arn_nr, name):
+    """Test the device initializes with the expected attributes"""
+
+    dev = BraketAwsAhsDevice(wires=3, shots=11, device_arn=arn_nr)
+
+    assert dev._device.name == name
+    assert dev.short_name == "braket.aws.ahs"
+    assert dev.shots == 11
+    assert dev.ahs_program is None
+    assert dev.samples is None
+    assert dev.pennylane_requires == ">=0.30.0"
+    assert dev.operations == {"ParametrizedEvolution"}
+
+
+class TestDeviceIntegration:
+    """Test the devices work correctly from the PennyLane frontend."""
+
+    @pytest.mark.parametrize("shortname, arn_nr, backend_name", ALL_DEVICES)
+    def test_load_device(self, shortname, arn_nr, backend_name):
+        """Test that the device loads correctly"""
+        dev = TestDeviceIntegration._device(shortname, arn_nr, wires=2)
+        assert dev.num_wires == 2
+        assert dev.shots == 100
+        assert dev.short_name == shortname
+        assert dev._device.name == backend_name
+
+    def test_args_hardware(self):
+        """Test that BraketAwsDevice requires correct arguments"""
+        with pytest.raises(TypeError, match="missing 2 required positional argument"):
+            qml.device("braket.aws.ahs")
+
+    def test_args_local(self):
+        """Test that BraketLocalDevice requires correct arguments"""
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            qml.device("braket.local.ahs")
+
+    @staticmethod
+    def _device(shortname, arn_nr, wires, shots=100):
+        if arn_nr:
+            return qml.device(shortname, wires=wires, device_arn=arn_nr, shots=shots)
+        return qml.device(shortname, wires=wires, shots=shots)
+
+
+class TestDeviceAttributes:
+    """Test application of PennyLane operations on hardware simulators."""
+
+    @pytest.mark.parametrize("shots", [1003, 2])
+    def test_setting_shots(self, shots):
+        """Test that setting shots changes number of shots from default (100)"""
+        dev = BraketLocalAhsDevice(wires=3, shots=shots)
+        assert dev.shots == shots
+
+        global_drive = rydberg_drive(2, 1, 2, wires=[0, 1, 2])
+        ts = [0.0, 1.75]
+
+        @qml.qnode(dev)
+        def circuit():
+            ParametrizedEvolution(H_i + global_drive, [], ts)
+            return qml.sample()
+
+        res = circuit()
+
+        assert len(res) == shots
+
+
+class TestQnodeIntegration:
+    """Test integration with the qnode"""
+
+    @pytest.mark.parametrize("H, params", HAMILTONIANS_AND_PARAMS)
+    def test_circuit_can_be_called(self, H, params):
+        """Test that the circuit consisting of a ParametrizedEvolution with a single, global pulse
+        runs successfully for all combinations of amplitude, phase and detuning being constants
+        or callables
+        """
+
+        dev = qml.device("braket.local.ahs", wires=3)
+
+        t = 1.13
+
+        @qml.qnode(dev)
+        def circuit():
+            ParametrizedEvolution(H, params, t)
+            return qml.sample()
+
+        circuit()

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+
 import json
 from dataclasses import dataclass
 from functools import partial

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -87,7 +87,6 @@ params1 = 1.2
 params2 = [3.4, 5.6]
 params_amp = [2.5, 0.9, 0.3]
 
-
 HAMILTONIANS_AND_PARAMS = [
     (H_i + rydberg_drive(amplitude=4, phase=1, detuning=3, wires=[0, 1, 2]), []),
     (H_i + rydberg_drive(amplitude=amp, phase=1, detuning=2, wires=[0, 1, 2]), [params_amp]),
@@ -202,7 +201,6 @@ def mock_aws_device(monkeypatch, wires=3):
 
 
 def dummy_ahs_program():
-
     # amplutide 10 for full duration
     amplitude = TimeSeries()
     amplitude.put(0, 10)
@@ -574,7 +572,6 @@ class TestBraketAhsDevice:
             assert detuning_sample == dev_sim._pulses[0].frequency(1.7)
         else:
             assert detuning_sample == dev_sim._pulses[0].frequency
-            
 
     @pytest.mark.parametrize("time_interval", [[1.5, 2.3], [0, 1.2], [0.111, 3.789]])
     def test_get_sample_times(self, time_interval):
@@ -597,7 +594,6 @@ class TestBraketAhsDevice:
         """Test creating a TimeSeries when the pulse parameter is defined as a constant float"""
 
         times = [0, 1, 2, 3, 4, 5]
-        
         ts = _convert_to_time_series(pulse_parameter=4.3, time_points=times)
 
         assert ts.times() == times
@@ -613,7 +609,6 @@ class TestBraketAhsDevice:
         times_s = [t * 1e-6 for t in times_us]  # seconds
 
         ts = _convert_to_time_series(pulse_parameter=f, time_points=times_s)
-
         expected_vals = [np.sin(t) for t in times_us]
 
         assert ts.times() == times_s

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -1,0 +1,873 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+import json
+from dataclasses import dataclass
+from functools import partial
+from unittest import mock
+from unittest.mock import Mock
+
+import numpy as np
+import pennylane as qml
+import pytest
+from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
+from braket.ahs.atom_arrangement import AtomArrangement
+from braket.ahs.driving_field import DrivingField
+from braket.aws import AwsDevice, AwsQuantumTask
+from braket.device_schema import DeviceActionProperties, DeviceActionType
+from braket.device_schema.quera.quera_ahs_paradigm_properties_v1 import QueraAhsParadigmProperties
+from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import ShotResult
+from braket.tasks.local_quantum_task import LocalQuantumTask
+from braket.timings.time_series import TimeSeries
+from pennylane.pulse.hardware_hamiltonian import HardwarePulse
+from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
+from pennylane.pulse.rydberg import rydberg_drive, rydberg_interaction
+
+from braket.pennylane_plugin.ahs_device import (
+    BraketAhsDevice,
+    BraketAwsAhsDevice,
+    BraketLocalAhsDevice,
+)
+from braket.pennylane_plugin.ahs_translation import (
+    _convert_to_time_series,
+    _create_register,
+    _evaluate_pulses,
+    _get_sample_times,
+    translate_ahs_shot_result,
+    translate_pulse_to_driving_field,
+)
+
+coordinates1 = [[0, 0], [0, 5], [5, 0], [10, 5], [5, 10], [10, 10]]
+wires1 = [1, 6, 0, 2, 4, 3]
+
+coordinates2 = [[0, 0], [5.5, 0.0], [2.75, 4.763139720814412]]  # in µm
+H_i = rydberg_interaction(coordinates2)
+
+
+def f1(p, t):
+    return p * np.sin(t) * (t - 1)
+
+
+def f2(p, t):
+    return p[0] * np.cos(p[1] * t**2)
+
+
+def amp(p, t):
+    return p[0] * np.exp(-((t - p[1]) ** 2) / (2 * p[2] ** 2))
+
+
+# functions of time to use as partially evaluated callable parameters in tests
+def sin_fn(t):
+    return np.sin(t)
+
+
+def cos_fn(t):
+    return np.cos(t)
+
+
+def lin_fn(t):
+    return 3.48 * t
+
+
+def quad_fn(t):
+    return 4.5 * t**2
+
+
+params1 = 1.2
+params2 = [3.4, 5.6]
+params_amp = [2.5, 0.9, 0.3]
+
+HAMILTONIANS_AND_PARAMS = [
+    (H_i + rydberg_drive(amplitude=4, phase=1, detuning=3, wires=[0, 1, 2]), []),
+    (H_i + rydberg_drive(amplitude=amp, phase=1, detuning=2, wires=[0, 1, 2]), [params_amp]),
+    (H_i + rydberg_drive(amplitude=2, phase=f1, detuning=2, wires=[0, 1, 2]), [params1]),
+    (H_i + rydberg_drive(amplitude=2, phase=2, detuning=f2, wires=[0, 1, 2]), [params2]),
+    (
+        H_i + rydberg_drive(amplitude=amp, phase=1, detuning=f2, wires=[0, 1, 2]),
+        [params_amp, params2],
+    ),
+    (H_i + rydberg_drive(amplitude=4, phase=f2, detuning=f1, wires=[0, 1, 2]), [params2, params1]),
+    (
+        H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=4, wires=[0, 1, 2]),
+        [params_amp, params2],
+    ),
+    (
+        H_i + rydberg_drive(amplitude=amp, phase=f2, detuning=f1, wires=[0, 1, 2]),
+        [params_amp, params2, params1],
+    ),
+]
+
+
+DEV_ATTRIBUTES = [(BraketAwsAhsDevice, "Aquila", "braket.aws.ahs")]
+
+dev_sim = BraketLocalAhsDevice(wires=3, shots=17)
+
+
+PARADIGM_PROPERTIES = QueraAhsParadigmProperties.parse_raw_schema(
+    json.dumps(
+        {
+            "braketSchemaHeader": {
+                "name": "braket.device_schema.quera.quera_ahs_paradigm_properties",
+                "version": "1",
+            },
+            "qubitCount": 256,
+            "lattice": {
+                "area": {"width": 0.000075, "height": 0.000076},
+                "geometry": {
+                    "spacingRadialMin": 0.000004,
+                    "spacingVerticalMin": 0.000004,
+                    "positionResolution": 1e-7,
+                    "numberSitesMax": 256,
+                },
+            },
+            "rydberg": {
+                "c6Coefficient": 5.42e-24,
+                "rydbergGlobal": {
+                    "rabiFrequencyRange": (0, 15800000.0),
+                    "rabiFrequencyResolution": 400.0,
+                    "rabiFrequencySlewRateMax": 250000000000000.0,
+                    "detuningRange": (-125000000.0, 125000000.0),
+                    "detuningResolution": 0.2,
+                    "detuningSlewRateMax": 2500000000000000.0,
+                    "phaseRange": (-99.0, 99.0),
+                    "phaseResolution": 5e-7,
+                    "timeResolution": 1e-9,
+                    "timeDeltaMin": 5e-8,
+                    "timeMin": 0,
+                    "timeMax": 0.000004,
+                },
+            },
+            "performance": {
+                "lattice": {"positionErrorAbs": 1.47e-7},
+                "rydberg": {"rydbergGlobal": {"rabiFrequencyErrorRel": 0.02}},
+            },
+        }
+    )
+)
+
+
+class MockAwsSession:
+    @staticmethod
+    def add_braket_user_agent(user_agent):
+        pass
+
+
+class MockDevProperties:
+    paradigm = PARADIGM_PROPERTIES
+    action = {
+        DeviceActionType.AHS: DeviceActionProperties(version=["1"], actionType=DeviceActionType.AHS)
+    }
+
+
+@pytest.fixture(scope="function")
+def mock_aws_device(monkeypatch, wires=3):
+    """A function to create a mock device that mocks most of the methods"""
+    with monkeypatch.context() as m:
+        m.setattr(AwsDevice, "__init__", lambda self, *args, **kwargs: None)
+        m.setattr(AwsDevice, "aws_session", MockAwsSession)
+        m.setattr(AwsDevice, "type", mock.PropertyMock)
+        m.setattr(AwsDevice, "properties", MockDevProperties)
+
+        def get_aws_device(
+            wires=wires,
+            shots=17,
+            device_arn="baz",
+            **kwargs,
+        ):
+            dev = BraketAwsAhsDevice(
+                wires=wires,
+                s3_destination_folder=("foo", "bar"),
+                device_arn=device_arn,
+                aws_session=Mock(),
+                shots=shots,
+                **kwargs,
+            )
+            # needed by BraketAwsAhsDevice functions
+            dev._device._arn = device_arn
+            dev._device._aws_session = Mock()
+            return dev
+
+        yield get_aws_device
+
+
+def dummy_ahs_program():
+    # amplutide 10 for full duration
+    amplitude = TimeSeries()
+    amplitude.put(0, 10)
+    amplitude.put(4e-6, 10)
+
+    # phase and detuning 0 for full duration
+    phi = TimeSeries().put(0, 0).put(4e-6, 0)
+    detuning = TimeSeries().put(0, 0).put(4e-6, 0)
+
+    # Hamiltonian
+    H = DrivingField(amplitude, phi, detuning)
+
+    # register
+    register = AtomArrangement()
+    for [x, y] in coordinates2:
+        register.add([x * 1e-6, y * 1e-6])
+
+    ahs_program = AnalogHamiltonianSimulation(hamiltonian=H, register=register)
+
+    return ahs_program
+
+
+# dummy data classes for testing result processing
+@dataclass
+class Status:
+    value: str
+
+
+@dataclass
+class DummyMeasurementResult:
+    status: Status
+    pre_sequence: np.array
+    post_sequence: np.array
+
+
+DUMMY_RESULTS = [
+    (DummyMeasurementResult(Status("Success"), np.array([1]), np.array([1])), np.array([0])),
+    (DummyMeasurementResult(Status("Success"), np.array([1]), np.array([0])), np.array([1])),
+    (DummyMeasurementResult(Status("Success"), np.array([0]), np.array([0])), np.array([np.NaN])),
+    (DummyMeasurementResult(Status("Failure"), np.array([1]), np.array([1])), np.array([np.NaN])),
+    (
+        DummyMeasurementResult(Status("Success"), np.array([1, 1, 0]), np.array([1, 0, 0])),
+        np.array([0, 1, np.NaN]),
+    ),
+    (
+        DummyMeasurementResult(Status("Success"), np.array([1, 1]), np.array([0, 0])),
+        np.array([1, 1]),
+    ),
+    (
+        DummyMeasurementResult(Status("Success"), np.array([0, 1]), np.array([0, 0])),
+        np.array([np.NaN, 1]),
+    ),
+    (
+        DummyMeasurementResult(Status("Failure"), np.array([1, 1]), np.array([1, 1])),
+        np.array([np.NaN, np.NaN]),
+    ),
+    (
+        DummyMeasurementResult(Status("Success"), np.array([0, 1]), np.array([1, 0])),
+        np.array([np.NaN, 1]),
+    ),
+]
+
+
+class TestBraketAhsDevice:
+    """Tests that behaviour defined for both the LocalSimulator and the
+    Aquila hardware in the base device work as expected"""
+
+    def test_initialization(self):
+        """Test the device initializes with the expected attributes"""
+
+        dev = BraketLocalAhsDevice(wires=3, shots=11)
+
+        assert dev._device.name == "RydbergAtomSimulator"
+        assert dev.short_name == "braket.local.ahs"
+        assert dev.shots == 11
+        assert dev.ahs_program is None
+        assert dev.samples is None
+        assert dev.pennylane_requires == ">=0.30.0"
+        assert dev.operations == {"ParametrizedEvolution"}
+
+    def test_settings(self):
+        dev = dev_sim
+        assert isinstance(dev.settings, dict)
+        assert "interaction_coeff" in dev.settings.keys()
+        assert len(dev.settings.keys()) == 1
+        assert dev.settings["interaction_coeff"] == 5420000
+
+    def test_run_task_not_implemented(self):
+        """Test that the _run_task method raises a NotImplemented error in the base class"""
+
+        dev = BraketAhsDevice(wires=2, device=None)
+        ahs_program = dummy_ahs_program()
+        with pytest.raises(NotImplementedError, match="not implemented for the base class"):
+            dev._run_task(ahs_program)
+
+    @pytest.mark.parametrize(
+        "dev_cls, shots", [(BraketLocalAhsDevice, 1000), (BraketLocalAhsDevice, 2)]
+    )
+    def test_setting_shots(self, dev_cls, shots):
+        """Test that setting shots changes number of shots from default (100)"""
+        dev = dev_cls(wires=3, shots=shots)
+        assert dev.shots == shots
+
+    @pytest.mark.parametrize("shots", [0, None])
+    def test_no_shots_raises_error(self, shots):
+        """Test that an error is raised if shots are set to 0 or None"""
+        with pytest.raises(RuntimeError, match="This device requires shots"):
+            BraketLocalAhsDevice(wires=3, shots=shots)
+
+    @pytest.mark.parametrize(
+        "dev_cls, wires",
+        [
+            (BraketLocalAhsDevice, 2),
+            (BraketLocalAhsDevice, [0, 2, 4]),
+            (BraketLocalAhsDevice, [0, "a", 7]),
+            (BraketLocalAhsDevice, 7),
+        ],
+    )
+    def test_setting_wires(self, dev_cls, wires):
+        """Test setting wires"""
+        dev = dev_cls(wires=wires)
+
+        if isinstance(wires, int):
+            assert len(dev.wires) == wires
+            assert dev.wires.labels == tuple(i for i in range(wires))
+        else:
+            assert len(wires) == len(dev.wires)
+            assert dev.wires.labels == tuple(wires)
+
+    @pytest.mark.parametrize("hamiltonian, params", HAMILTONIANS_AND_PARAMS)
+    def test_apply(self, hamiltonian, params):
+        """Test that apply creates and saves an ahs_program and samples as expected"""
+        t = 0.4
+        operations = [ParametrizedEvolution(hamiltonian, params, t)]
+        dev = BraketLocalAhsDevice(wires=operations[0].wires)
+
+        assert dev._task is None
+        assert dev.task is None
+        assert dev.samples is None
+        assert dev.ahs_program is None
+
+        dev.apply(operations)
+
+        assert dev.samples is not None
+        assert dev.task is not None
+        assert dev.task == dev._task
+        assert len(dev.samples.measurements) == dev.shots
+        assert len(dev.samples.measurements[0].pre_sequence) == len(dev.wires)
+
+        assert isinstance(dev.ahs_program, AnalogHamiltonianSimulation)
+        assert dev.ahs_program.register == dev.register
+        assert dev.ahs_program.hamiltonian.amplitude.time_series.times()[-1] == t * 1e-6
+
+    def test_apply_unsupported(self):
+        """Tests that apply() throws NotImplementedError when it encounters an unknown gate."""
+
+        with pytest.raises(NotImplementedError):
+            dev_sim.apply([qml.PauliX(0)])
+
+    @pytest.mark.parametrize("hamiltonian, params", HAMILTONIANS_AND_PARAMS)
+    def test_create_ahs_program(self, hamiltonian, params):
+        """Test that we can create an AnalogueHamiltonianSimulation from an
+        evolution operator and store it on the device"""
+
+        evolution = ParametrizedEvolution(hamiltonian, params, 1.5)
+        dev = BraketLocalAhsDevice(wires=3)
+
+        assert dev.ahs_program is None
+
+        ahs_program = dev.create_ahs_program(evolution)
+
+        # AHS program is created and stored on the device
+        assert isinstance(dev.ahs_program, AnalogHamiltonianSimulation)
+
+        # compare evolution and ahs_program registers
+        assert ahs_program.register.coordinate_list(0) == [
+            c[0] * 1e-6 for c in evolution.H.settings.register
+        ]
+        assert ahs_program.register.coordinate_list(1) == [
+            c[1] * 1e-6 for c in evolution.H.settings.register
+        ]
+
+        # elements of the hamiltonian have the expected shape
+        h = ahs_program.hamiltonian
+        amp_time, amp_vals = h.amplitude.time_series.times(), h.amplitude.time_series.values()
+        phase_time, phase_vals = h.phase.time_series.times(), h.phase.time_series.values()
+        det_time, det_vals = h.detuning.time_series.times(), h.detuning.time_series.values()
+
+        assert amp_time == phase_time == det_time
+        assert amp_time[0] == evolution.t[0] * 1e-6
+        assert amp_time[-1] == evolution.t[1] * 1e-6
+
+        pulse = hamiltonian.pulses[0]
+        params_idx = 0
+
+        if callable(pulse.amplitude):
+            fn = pulse.amplitude
+            p = params[params_idx]
+            params_idx += 1
+            assert np.allclose([fn(p, t * 1e6) * 1e6 for t in amp_time], amp_vals)
+        else:
+            assert np.allclose([pulse.amplitude * 1e6 for t in amp_time], amp_vals)
+
+        if callable(pulse.phase):
+            fn = pulse.phase
+            p = params[params_idx]
+            params_idx += 1
+            assert np.allclose([fn(p, t * 1e6) for t in amp_time], phase_vals)
+        else:
+            assert np.allclose([pulse.phase for t in amp_time], phase_vals)
+
+        if callable(pulse.frequency):
+            fn = pulse.frequency
+            p = params[params_idx]
+            params_idx += 1
+            assert np.allclose([fn(p, t * 1e6) * 1e6 for t in amp_time], det_vals)
+        else:
+            assert np.allclose([pulse.frequency * 1e6 for t in amp_time], det_vals)
+
+    def test_generate_samples(self):
+        """Test that generate_samples creates a list of arrays with the expected shape for the
+        task run"""
+        ahs_program = dummy_ahs_program()
+
+        # checked in _validate_operations in the full pipeline
+        # since these are created manually for the unit test elsewhere in the file,
+        # we confirm the values used for the test are valid here
+        assert len(ahs_program.register.coordinate_list(0)) == len(dev_sim.wires)
+
+        task = dev_sim._run_task(ahs_program)
+
+        dev_sim._task = task
+
+        samples = dev_sim.generate_samples()
+
+        assert len(samples) == 17
+        assert len(samples[0]) == len(dev_sim.wires)
+        assert isinstance(samples[0], np.ndarray)
+
+    def test_validate_operations_multiple_operators(self):
+        """Test that an error is raised if there are multiple operators"""
+
+        H1 = rydberg_drive(amp, f1, 2, wires=[0, 1, 2])
+        op1 = qml.evolve(H_i + H1)
+        op2 = qml.evolve(H_i + H1)
+
+        with pytest.raises(
+            NotImplementedError, match="Support for multiple ParametrizedEvolution operators"
+        ):
+            dev_sim._validate_operations([op1, op2])
+
+    def test_validate_operations_wires_match_device(self):
+        """Test that an error is raised if the wires on the Hamiltonian
+        don't match the wires on the device."""
+        H = H_i + rydberg_drive(3, 2, 2, wires=[0, 1, 2])
+
+        dev1 = BraketLocalAhsDevice(wires=len(H.wires) - 1)
+        dev2 = BraketLocalAhsDevice(wires=len(H.wires) + 1)
+
+        with pytest.raises(RuntimeError, match="Device wires must match wires of the evolution."):
+            dev1._validate_operations([ParametrizedEvolution(H, [], 1)])
+
+        with pytest.raises(RuntimeError, match="Device wires must match wires of the evolution."):
+            dev2._validate_operations([ParametrizedEvolution(H, [], 1)])
+
+    def test_validate_operations_register_matches_wires(self):
+        """Test that en error is raised in the length of the register doesn't match
+        the number of wires on the device"""
+
+        # register has wires [0, 1, 2], drive has wire [3]
+        # creating a Hamiltonian like this in PL will raise a warning, but not an error
+        H = H_i + rydberg_drive(3, 2, 2, wires=3)
+
+        # device wires [0, 1, 2, 3] match overall wires, but not length of register
+        dev = BraketLocalAhsDevice(wires=4)
+
+        with pytest.raises(RuntimeError, match="The defined interaction term has register"):
+            dev._validate_operations([ParametrizedEvolution(H, [], 1)])
+
+    def test_validate_operations_not_hardware_hamiltonian(self):
+        """Test that an error is raised if the ParametrizedHamiltonian on the operator
+        is not a HardwareHamiltonian and so does not contain pulse upload information"""
+
+        H1 = 2 * qml.PauliX(0) + f1 * qml.PauliY(1) + f2 * qml.PauliZ(2)
+        op1 = qml.evolve(H1)
+
+        with pytest.raises(RuntimeError, match="Expected a HardwareHamiltonian instance"):
+            dev_sim._validate_operations([op1])
+
+    def test_validate_pulses_no_pulses(self):
+        """Test that _validate_pulses raises an error if there are no pulses saved
+        on the Hamiltonian"""
+
+        with pytest.raises(RuntimeError, match="No pulses found"):
+            dev_sim._validate_pulses(H_i.pulses)
+
+    @pytest.mark.parametrize("coordinates", [coordinates1, coordinates2])
+    def test_create_register(self, coordinates):
+        """Test that an AtomArrangement with the expected coordinates is created
+        and stored on the device"""
+
+        dev = BraketLocalAhsDevice(wires=len(coordinates))
+
+        assert dev.register is None
+
+        dev._register = _create_register(coordinates)
+
+        coordinates_from_register = [
+            [x * 1e6, y * 1e6]
+            for x, y in zip(dev.register.coordinate_list(0), dev.register.coordinate_list(1))
+        ]
+
+        assert isinstance(dev.register, AtomArrangement)
+        assert coordinates_from_register == coordinates
+
+    @pytest.mark.parametrize("hamiltonian, params", HAMILTONIANS_AND_PARAMS)
+    def test_evaluate_pulses(self, hamiltonian, params):
+        """Test that the callables describing pulses are partially evaluated as expected"""
+
+        ev_op = ParametrizedEvolution(hamiltonian, params, 1.5)
+
+        pulse = ev_op.H.pulses[0]
+        params = ev_op.parameters
+        idx = 0
+
+        # check which of initial pulse parameters are callable
+        callable_amp = callable(pulse.amplitude)
+        callable_phase = callable(pulse.phase)
+        callable_detuning = callable(pulse.frequency)
+
+        # get an expected value for each pulse parameter at t=1.7
+        if callable_amp:
+            amp_sample = pulse.amplitude(params[idx], 1.7)
+            idx += 1
+        else:
+            amp_sample = pulse.amplitude
+
+        if callable_phase:
+            phase_sample = pulse.phase(params[idx], 1.7)
+            idx += 1
+        else:
+            phase_sample = pulse.phase
+
+        if callable_detuning:
+            detuning_sample = pulse.frequency(params[idx], 1.7)
+            idx += 1
+        else:
+            detuning_sample = pulse.frequency
+
+        # evaluate pulses
+        dev_sim._pulses = _evaluate_pulses(ev_op)
+
+        # confirm that if initial pulse parameter was a callable, it is now a partial
+        # confirm that post-evaluation value at t=1.7 seconds matches expectation
+        if callable_amp:
+            assert isinstance(dev_sim._pulses[0].amplitude, partial)
+            assert amp_sample == dev_sim._pulses[0].amplitude(1.7)
+        else:
+            assert amp_sample == dev_sim._pulses[0].amplitude
+
+        if callable_phase:
+            assert isinstance(dev_sim._pulses[0].phase, partial)
+            assert phase_sample == dev_sim._pulses[0].phase(1.7)
+        else:
+            assert phase_sample == dev_sim._pulses[0].phase
+
+        if callable_detuning:
+            assert isinstance(dev_sim._pulses[0].frequency, partial)
+            assert detuning_sample == dev_sim._pulses[0].frequency(1.7)
+        else:
+            assert detuning_sample == dev_sim._pulses[0].frequency
+
+    @pytest.mark.parametrize("time_interval", [[1.5, 2.3], [0, 1.2], [0.111, 3.789]])
+    def test_get_sample_times(self, time_interval):
+        """Tests turning an array of [start, end] times into time set-points"""
+
+        times = _get_sample_times(time_interval)
+
+        num_points = len(times)
+        diffs = [times[i] - times[i - 1] for i in range(1, num_points)]
+
+        # start and end times match but are in units of s and us respectively
+        assert times[0] * 1e6 == time_interval[0]
+        assert times[-1] * 1e6 == time_interval[1]
+
+        # distances between points are close to but exceed 50ns
+        assert all(d > 50e-9 for d in diffs)
+        assert np.allclose(diffs, 50e-9, atol=5e-9)
+
+    def test_convert_to_time_series_constant(self):
+        """Test creating a TimeSeries when the pulse parameter is defined as a constant float"""
+
+        times = [0, 1, 2, 3, 4, 5]
+        ts = _convert_to_time_series(pulse_parameter=4.3, time_points=times)
+
+        assert ts.times() == times
+        assert all(p == 4.3 for p in ts.values())
+
+    def test_convert_to_time_series_callable(self):
+        """Test creating a TimeSeries when the pulse parameter is defined as a function of time"""
+
+        def f(t):
+            return np.sin(t)
+
+        times_us = [0, 1, 2, 3, 4, 5]  # microseconds
+        times_s = [t * 1e-6 for t in times_us]  # seconds
+
+        ts = _convert_to_time_series(pulse_parameter=f, time_points=times_s)
+        expected_vals = [np.sin(t) for t in times_us]
+
+        assert ts.times() == times_s
+        assert np.all(ts.values() == expected_vals)
+
+    def test_convert_to_time_series_scaling_factor(self):
+        """Test creating a TimeSeries from pulse information and time set-points"""
+
+        def f(t):
+            return np.sin(t)
+
+        times_us = [0, 1, 2, 3, 4, 5]  # microseconds
+        times_s = [t * 1e-6 for t in times_us]  # seconds
+
+        ts = _convert_to_time_series(pulse_parameter=f, time_points=times_s, scaling_factor=1.7)
+        expected_vals = [np.sin(t) * 1.7 for t in times_us]
+
+        assert ts.times() == times_s
+        assert ts.values() == expected_vals
+
+    @pytest.mark.parametrize(
+        "pulse",
+        [
+            HardwarePulse(1, 2, sin_fn, wires=[0, 1, 2]),
+            HardwarePulse(cos_fn, 1.7, 2.3, wires=[0, 1, 2]),
+            HardwarePulse(3.8, lin_fn, 1.9, wires=[0, 1, 2]),
+            HardwarePulse(lin_fn, sin_fn, quad_fn, wires=[0, 1, 2]),
+        ],
+    )
+    def test_translate_pulse_to_driving_field(self, pulse):
+        """Test that a time interval in microseconds (as passed to the qnode in PennyLane)
+        and a Pulse object containing constant or time-dependent pulse parameters (floats
+        and/or callables that have been evaluated to be a function only of time)
+        and can be converted into a DrivingField
+        """
+
+        drive = translate_pulse_to_driving_field(pulse, [0, 1.5])
+
+        assert isinstance(drive, DrivingField)
+
+    @pytest.mark.parametrize("res, expected_output", DUMMY_RESULTS)
+    def test_result_to_sample_output(self, res, expected_output):
+        """Test function for converting the task results as returned by the
+        device into sample measurement results for PennyLane"""
+
+        output = translate_ahs_shot_result(res)
+
+        assert isinstance(output, np.ndarray)
+        assert len(output) == len(res.post_sequence)
+        assert np.allclose(output, expected_output, equal_nan=True)
+
+
+class TestLocalAquilaDevice:
+    """Test functionality specific to the local simulator device"""
+
+    def test_validate_operations_multiple_drive_terms(self):
+        """Test that an error is raised if there are multiple drive terms on
+        the Hamiltonian"""
+        pulses = [HardwarePulse(3, 4, 5, [0, 1]), HardwarePulse(4, 6, 7, [1, 2])]
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Multiple pulses in a Hamiltonian are not currently supported",
+        ):
+            dev_sim._validate_pulses(pulses)
+
+    @pytest.mark.parametrize(
+        "pulse_wires, dev_wires, res",
+        [
+            ([0, 1, 2], [0, 1, 2, 3], "error"),  # subset
+            ([5, 6, 7, 8, 9], [4, 5, 6, 7, 8], "error"),  # mismatch
+            ([0, 1, 2, 3, 6], [1, 2, 3], "error"),
+            ([0, 1, 2], [0, 1, 2], "success"),
+        ],
+    )
+    def test_validate_pulse_is_global_drive(self, pulse_wires, dev_wires, res):
+        """Test that an error is raised if the pulse does not describe a global drive"""
+
+        dev = BraketLocalAhsDevice(wires=dev_wires)
+        pulse = HardwarePulse(3, 4, 5, pulse_wires)
+
+        if res == "error":
+            with pytest.raises(
+                NotImplementedError, match="Only global drive is currently supported"
+            ):
+                dev._validate_pulses([pulse])
+        else:
+            dev._validate_pulses([pulse])
+
+    def test_run_task(self):
+        ahs_program = dummy_ahs_program()
+
+        task = dev_sim._run_task(ahs_program)
+
+        assert isinstance(task, LocalQuantumTask)
+        assert len(task.result().measurements) == 17  # dev_sim takes 17 shots
+        assert isinstance(task.result().measurements[0], ShotResult)
+
+
+class TestBraketAwsAhsDevice:
+    """Test functionality specific to the hardware device"""
+
+    def test_initialize(self, mock_aws_device):
+        """Test the device initializes with the expected attributes"""
+        dev = mock_aws_device()
+
+        assert dev._s3_folder == ("foo", "bar")
+        assert dev.shots == 17
+        assert dev.ahs_program is None
+        assert dev.samples is None
+        assert dev.pennylane_requires == ">=0.30.0"
+        assert dev.operations == {"ParametrizedEvolution"}
+        assert dev.short_name == "braket.aws.ahs"
+
+    def test_hardware_capabilities(self, mock_aws_device):
+        """Test hardware capabilities can be retrieved"""
+
+        dev = mock_aws_device()
+
+        assert isinstance(dev.hardware_capabilities, dict)
+        assert dev.hardware_capabilities == dict(PARADIGM_PROPERTIES)
+
+    def test_settings(self, mock_aws_device):
+        dev = mock_aws_device()
+        assert list(dev.settings.keys()) == ["interaction_coeff"]
+        assert np.isclose(dev.settings["interaction_coeff"], 5420000)
+
+    def test_validate_operations_multiple_drive_terms(self, mock_aws_device):
+        """Test that an error is raised if there are multiple drive terms on
+        the Hamiltonian"""
+        dev = mock_aws_device()
+        pulses = [HardwarePulse(3, 4, 5, [0, 1]), HardwarePulse(4, 6, 7, [1, 2])]
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Multiple pulses in a Hamiltonian are not currently supported",
+        ):
+            dev._validate_pulses(pulses)
+
+    @pytest.mark.parametrize(
+        "pulse_wires, dev_wires, res",
+        [
+            ([0, 1, 2], [0, 1, 2, 3], "error"),
+            ([5, 6, 7, 8, 9], [4, 5, 6, 7, 8], "error"),
+            ([0, 1, 2, 3, 6], [1, 2, 3], "error"),
+            ([0, 1, 2], [0, 1, 2], "success"),
+        ],
+    )
+    def test_validate_pulse_is_global_drive(self, mock_aws_device, pulse_wires, dev_wires, res):
+        """Test that an error is raised if the pulse does not describe a global drive"""
+
+        dev = mock_aws_device(wires=dev_wires)
+        pulse = HardwarePulse(3, 4, 5, pulse_wires)
+
+        if res == "error":
+            with pytest.raises(
+                NotImplementedError, match="Only global drive is currently supported"
+            ):
+                dev._validate_pulses([pulse])
+        else:
+            dev._validate_pulses([pulse])
+
+    def test_get_rydberg_c6(self, mock_aws_device):
+        """Test that _get_rydberg_c6 retrieves the c6 coefficient from the hardware properties
+        and converts to expected PennyLane units"""
+
+        dev = mock_aws_device()
+        c6 = dev._get_rydberg_c6()
+
+        assert np.isclose(
+            float(2 * np.pi * c6 / 1e30),
+            float(dev._device.properties.paradigm.rydberg.c6Coefficient),
+        )
+
+    @pytest.mark.parametrize("hamiltonian, params", HAMILTONIANS_AND_PARAMS)
+    def test_create_ahs_program(self, hamiltonian, params, mock_aws_device):
+        """Test that we can create an AnalogueHamiltonianSimulation from an
+        evolution operator and store it on the device"""
+
+        evolution = ParametrizedEvolution(hamiltonian, params, 1.5)
+        dev = mock_aws_device()
+
+        assert dev.ahs_program is None
+
+        ahs_program = dev.create_ahs_program(evolution)
+
+        # AHS program is created and stored on the device
+        assert isinstance(dev.ahs_program, AnalogHamiltonianSimulation)
+
+        # compare evolution and ahs_program registers
+        assert np.allclose(
+            [float(c) for c in ahs_program.register.coordinate_list(0)],
+            [c[0] * 1e-6 for c in evolution.H.settings.register],
+            atol=1e-6,
+        )
+        assert np.allclose(
+            [float(c) for c in ahs_program.register.coordinate_list(1)],
+            [float(c[1] * 1e-6) for c in evolution.H.settings.register],
+            atol=1e-6,
+        )
+
+        # elements of the hamiltonian have the expected shape
+        h = ahs_program.hamiltonian
+        amp_time, amp_vals = h.amplitude.time_series.times(), h.amplitude.time_series.values()
+        phase_time, phase_vals = h.phase.time_series.times(), h.phase.time_series.values()
+        det_time, det_vals = h.detuning.time_series.times(), h.detuning.time_series.values()
+
+        assert amp_time == phase_time == det_time
+        assert float(amp_time[0]) == evolution.t[0] * 1e-6
+        assert float(amp_time[-1]) == evolution.t[1] * 1e-6
+
+        pulse = hamiltonian.pulses[0]
+        params_idx = 0
+
+        if callable(pulse.amplitude):
+            fn = pulse.amplitude
+            p = params[params_idx]
+            params_idx += 1
+            # atol 200 because of discretization, i.e. 27772.49134560574 --> 27600.0
+            assert np.allclose(
+                [fn(p, float(t) * 1e6) * 1e6 for t in amp_time],
+                [float(v) for v in amp_vals],
+                atol=200,
+            )
+        else:
+            assert np.allclose(
+                [pulse.amplitude * 1e6 for t in amp_time], [float(v) for v in amp_vals], atol=200
+            )
+
+        if callable(pulse.phase):
+            fn = pulse.phase
+            p = params[params_idx]
+            params_idx += 1
+            assert np.allclose(
+                [fn(p, float(t) * 1e6) for t in amp_time], [float(v) for v in phase_vals], atol=1e-7
+            )
+        else:
+            assert np.allclose(
+                [pulse.phase for t in amp_time], [float(v) for v in phase_vals], atol=1e-7
+            )
+
+        if callable(pulse.frequency):
+            fn = pulse.frequency
+            p = params[params_idx]
+            params_idx += 1
+            assert np.allclose(
+                [fn(p, float(t) * 1e6) * 1e6 for t in amp_time], [float(v) for v in det_vals]
+            )
+        else:
+            assert np.allclose(
+                [pulse.frequency * 1e6 for t in amp_time], [float(v) for v in det_vals]
+            )
+
+    def test_run_task(self, mock_aws_device):
+        """Tests that a (mock) task can be created"""
+        dev = mock_aws_device()
+        ahs_program = dummy_ahs_program()
+
+        task = dev._run_task(ahs_program)
+
+        assert isinstance(task, AwsQuantumTask)

--- a/test/unit_tests/test_braket_device.py
+++ b/test/unit_tests/test_braket_device.py
@@ -1235,25 +1235,38 @@ def test_projection():
     def f(thetas, **kwargs):
         [qml.RY(thetas[i], wires=i) for i in range(wires)]
 
-    measure_types = ["expval", "var", "sample"]
     projector_01 = qml.Projector([0, 1], wires=range(wires))
     projector_10 = qml.Projector([1, 0], wires=range(wires))
 
     # 01 case
-    fs = [qml.map(f, [projector_01], dev, measure=m) for m in measure_types]
-    assert np.allclose(fs[0](thetas), p_01)
-    assert np.allclose(fs[1](thetas), p_01 - p_01**2)
+    @qml.qnode(dev)
+    def f_01(thetas, measure_type):
+        f(thetas)
+        return measure_type(projector_01)
 
-    samples = fs[2](thetas, shots=100)[0].tolist()
-    assert set(samples) == {0, 1}
+    expval_01 = f_01(thetas, qml.expval)
+    assert np.allclose(expval_01, p_01)
+
+    var_01 = f_01(thetas, qml.var)
+    assert np.allclose(var_01, p_01 - p_01**2)
+
+    samples = f_01(thetas, qml.sample, shots=100).tolist()
+    assert set(samples[0]) == {0, 1}
 
     # 10 case
-    fs = [qml.map(f, [projector_10], dev, measure=m) for m in measure_types]
-    assert np.allclose(fs[0](thetas), p_10)
-    assert np.allclose(fs[1](thetas), p_10 - p_10**2)
+    @qml.qnode(dev)
+    def f_10(thetas, measure_type):
+        f(thetas)
+        return measure_type(projector_10)
 
-    samples = fs[2](thetas, shots=100)[0].tolist()
-    assert set(samples) == {0, 1}
+    exp_10 = f_10(thetas, qml.expval)
+    assert np.allclose(exp_10, p_10)
+
+    var_10 = f_10(thetas, qml.var)
+    assert np.allclose(var_10, p_10 - p_10**2)
+
+    samples = f_10(thetas, qml.sample, shots=100).tolist()
+    assert set(samples[0]) == {0, 1}
 
 
 @pytest.mark.xfail(raises=AttributeError)

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     sphinx-automodapi
     sphinx-rtd-theme
     sphinxcontrib-apidoc
+    pennylane_sphinx_theme
 commands =
     sphinx-build -E -T -b html doc build/documentation/html
 


### PR DESCRIPTION
*Description of changes:*
Adds documentation for the AHS device, including:

-  adding pages for `braket.aws.ahs` and `braket.local.ahs` under `Usage`
- adding cards for the two new devices to the main plugin page
- modifying language surrounding the existing devices to clarify which are gate-based vs AHS devices