### PR TITLE
Expectation Value support

### DIFF
--- a/src/braket/pennylane_plugin/ahs_device.py
+++ b/src/braket/pennylane_plugin/ahs_device.py
@@ -62,7 +62,7 @@ class BraketAhsDevice(QubitDevice):
     """
 
     name = "Braket AHS PennyLane plugin"
-    pennylane_requires = ">=0.30.0"
+    pennylane_requires = ">=0.29.0"
     version = __version__
     author = "Xanadu Inc."
 
@@ -158,7 +158,7 @@ class BraketAhsDevice(QubitDevice):
         Returns:
              array[complex]: array of samples in the shape ``(dev.shots, dev.num_wires)``
         """
-        return [self._result_to_sample_output(res) for res in self.samples.measurements]
+        return np.array([self._result_to_sample_output(res) for res in self.samples.measurements])
 
     def _validate_operations(self, operations):
         """Confirms that the list of operations provided contains a single ParametrizedEvolution

--- a/test/integ_tests/test_ahs_device.py
+++ b/test/integ_tests/test_ahs_device.py
@@ -186,3 +186,17 @@ class TestQnodeIntegration:
             return qml.sample()
 
         circuit()
+
+    def test_qnode_expval(self):
+        """Test that a qnode with multiple measurements has the correct shape"""
+        dev = qml.device("braket.local.ahs", wires=3)
+
+        H = H_i + rydberg_drive(3, 2, 1, [0, 1, 2])
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.evolve(H)([], 1.8)
+            return qml.expval(qml.PauliZ(0))
+
+        res = circuit()
+        assert res.shape == ()

--- a/test/unit_tests/test_ahs_device.py
+++ b/test/unit_tests/test_ahs_device.py
@@ -339,20 +339,20 @@ class TestBraketAhsDevice:
     def test_generate_samples(self):
         """Test that generate_samples creates a list of arrays with the expected shape for the task run"""
         ahs_program = dummy_ahs_program()
+        dev = qml.device("braket.local.ahs", wires=3)
 
         # checked in _validate_operations in the full pipeline
         # since these are created manually for the unit test elsewhere in the file,
         # we confirm the values used for the test are valid here
-        assert len(ahs_program.register.coordinate_list(0)) == len(dev_sim.wires)
+        assert len(ahs_program.register.coordinate_list(0)) == len(dev.wires)
 
-        task = dev_sim._run_task(ahs_program)
+        task = dev._run_task(ahs_program)
 
-        dev_sim.samples = task.result()
+        dev._task = task
+        samples = dev.generate_samples()
 
-        samples = dev_sim.generate_samples()
-
-        assert len(samples) == 17
-        assert len(samples[0]) == len(dev_sim.wires)
+        assert len(samples) == 1000
+        assert len(samples[0]) == len(dev.wires)
         assert isinstance(samples[0], np.ndarray)
 
     def test_validate_operations_multiple_operators(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed `BraketAhsDevice.generate_samples` to return a numpy array instead of a list. This allows various measurements to work with the AHS devices, such as `expval`, `var`, `probs`. Note: `probs` is still a bit buggy and will need some more debugging before review.

*Testing done:*
* Added integration tests to verify that `expval` works. Testing for other return types will be added before opening for review.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-pennylane-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.