### PR TITLE
Wire mapping fix

### DIFF
--- a/src/braket/pennylane_plugin/braket_device.py
+++ b/src/braket/pennylane_plugin/braket_device.py
@@ -424,7 +424,7 @@ class BraketQubitDevice(QubitDevice):
                 operation,
                 use_unique_params=bool(trainable_indices) or use_unique_params,
                 param_names=param_names,
-                device=self,
+                device=self._device,
             )
 
             ins = Instruction(gate, dev_wires)

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -182,6 +182,7 @@ def translate_operation(
             p.numpy() if isinstance(p, qml.numpy.tensor) else p for p in operation.parameters
         ]
     device = kwargs.get("device", None)
+    print(type(device))
     return _translate_operation(operation, parameters, device)
 
 
@@ -445,7 +446,7 @@ def _(op: ParametrizedEvolution, _parameters, device=None):
     # The driven wires aren't the same as `op.wires` as `op.wires` contains
     # all device wires due to interaction term.
     pulse_wires = qml.wires.Wires.all_wires([pulse.wires for pulse in pulses])
-    frames = {w: device._device.frames[f"q{w}_drive"] for w in pulse_wires}
+    frames = {w: device.frames[f"q{w}_drive"] for w in pulse_wires}
 
     # take dt from first frame (all frames have identical dt)
     time_step = list(frames.values())[0].port.dt * 1e9  # seconds to nanoseconds

--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -182,7 +182,6 @@ def translate_operation(
             p.numpy() if isinstance(p, qml.numpy.tensor) else p for p in operation.parameters
         ]
     device = kwargs.get("device", None)
-    print(type(device))
     return _translate_operation(operation, parameters, device)
 
 

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -483,7 +483,7 @@ def test_translate_parametrized_evolution_constant_amplitude():
     H = transmon_drive(0.02, np.pi, 0.5, [0])
     op = ParametrizedEvolution(H, [], t=50)
 
-    braket_gate = translate_operation(op, device=dev)
+    braket_gate = translate_operation(op, device=dev._device)
 
     assert isinstance(braket_gate, gates.PulseGate)
     assert braket_gate.qubit_count == 1
@@ -515,7 +515,7 @@ def test_translate_parametrized_evolution_callable():
     frequency_param = 3.5
     op = ParametrizedEvolution(H, [amplitude_param, phase_param, frequency_param], t=50)
 
-    braket_gate = translate_operation(op, device=dev)
+    braket_gate = translate_operation(op, device=dev._device)
 
     assert isinstance(braket_gate, gates.PulseGate)
     assert braket_gate.qubit_count == 1
@@ -551,7 +551,7 @@ def test_translate_parametrized_evolution_mixed():
     frequency_param = 4.0
     op = ParametrizedEvolution(H, [phase_param, amplitude_param, frequency_param], t=50)
 
-    braket_gate = translate_operation(op, device=dev)
+    braket_gate = translate_operation(op, device=dev._device)
 
     assert isinstance(braket_gate, gates.PulseGate)
     assert braket_gate.qubit_count == 2
@@ -592,7 +592,7 @@ def test_translate_parametrized_evolution_multi_callable_amplitudes():
     second_amp_param = [0.5, np.pi, 3]
     op = ParametrizedEvolution(H, [first_amp_param, 3.5, second_amp_param], t=50)
 
-    braket_gate = translate_operation(op, device=dev)
+    braket_gate = translate_operation(op, device=dev._device)
     assert braket_gate.qubit_count == 2
 
     ps = braket_gate.pulse_sequence


### PR DESCRIPTION
Remove custom wire logic to avoid ambiguity; wire `5` is always qubit 5, wire `3` is always qubit 3, and there is no wire `'a'`