### PR TITLE
Use ConstantWaveform for pulse.constant amplitude

### DIFF
--- a/src/braket/pennylane_plugin/translation.py
+++ b/src/braket/pennylane_plugin/translation.py
@@ -456,15 +456,22 @@ def _(op: ParametrizedEvolution, _parameters, device=None):
     for pulse in pulses:
         # Create waveform for each pulse in `ParametrizedEvolution`
         if callable(pulse.amplitude):
-            amplitude = partial(pulse.amplitude, op.parameters[callable_index])
-            callable_index += 1
 
-            # Calculate amplitude for each time step and normalize
-            amplitudes = onp.array(
-                [amplitude(t) for t in np.arange(start, end + time_step, time_step)]
-            )
+            if pulse.amplitude == qml.pulse.constant:
+                amplitude = float(op.parameters[callable_index])
+                callable_index += 1
+                waveform = ConstantWaveform(pulse_length, amplitude)
 
-            waveform = ArbitraryWaveform(amplitudes)
+            else:
+                amplitude = partial(pulse.amplitude, op.parameters[callable_index])
+                callable_index += 1
+
+                # Calculate amplitude for each time step and normalize
+                amplitudes = onp.array(
+                    [amplitude(t) for t in np.arange(start, end + time_step, time_step)]
+                )
+
+                waveform = ArbitraryWaveform(amplitudes)
 
         else:
             waveform = ConstantWaveform(pulse_length, pulse.amplitude)

--- a/test/unit_tests/test_translation.py
+++ b/test/unit_tests/test_translation.py
@@ -502,6 +502,34 @@ def test_translate_parametrized_evolution_constant_amplitude():
     assert np.isclose(waveforms[0].iq, 0.02)
 
 
+def test_translate_parametrized_evolution_constant_callable_amplitude():
+    """Test that a ParametrizedEvolution with constant amplitude, phase, and frequency
+    is translated to a PulseGate correctly."""
+    n_wires = 4
+    dev = _aws_device(wires=n_wires)
+
+    H = transmon_drive(qml.pulse.constant, np.pi, 0.5, [0])
+    op = ParametrizedEvolution(H, [0.2], t=50)
+
+    braket_gate = translate_operation(op, device=dev._device)
+
+    assert isinstance(braket_gate, gates.PulseGate)
+    assert braket_gate.qubit_count == 1
+
+    ps = braket_gate.pulse_sequence
+    expected_frame = dev._device.frames["q0_drive"]
+
+    frames = list(ps._frames.values())
+    assert len(frames) == 1
+    assert frames[0] == expected_frame
+
+    waveforms = list(ps._waveforms.values())
+    assert len(waveforms) == 1
+    assert isinstance(waveforms[0], ConstantWaveform)
+    assert np.isclose(waveforms[0].length, 50e-9)
+    assert np.isclose(waveforms[0].iq, 0.2)
+
+
 def test_translate_parametrized_evolution_callable():
     """Test that a ParametrizedEvolution with callable amplitude, phase, and frequency
     is translated to a PulseGate correctly."""


### PR DESCRIPTION
Use `ConstantWaveform` instead of `ArbitraryWaveform` if the amplitude is specified as a `qml.pulse.constant` callable